### PR TITLE
Fix license link

### DIFF
--- a/index.md
+++ b/index.md
@@ -263,5 +263,4 @@ GitHub](https://github.com/mojombo/semver/issues).
 License
 -------
 
-Creative Commons - CC BY 3.0
-http://creativecommons.org/licenses/by/3.0/
+[Creative Commons - CC BY 3.0](http://creativecommons.org/licenses/by/3.0/)


### PR DESCRIPTION
**Look at:**
![lcsmvr](https://f.cloud.github.com/assets/2725611/1128563/fdb10606-1b6c-11e3-8586-d3290bb6a6fe.png)

Last link isn't parsed. I fixed it.
