### PR TITLE
Updated font declaration to include Helvetica and sans-serif in addition to Arial

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -6,10 +6,10 @@ CSS for semver.org
 
 h1, h2, ol { margin: 0; padding: 0; }
 
-html { font: 14.4px/1.5 Arial; }
+html { font: 14.4px/1.5 Helvetica, Arial, sans-serif; }
 body { margin: 0 auto; padding: 0 10%; max-width: 710px; }
 
-@-ms-viewport { width: device-width; } 
+@-ms-viewport { width: device-width; }
 html { -webkit-text-size-adjust: 100%; }
 
 h1, h2, h3 { text-align: center; font-weight: normal; }
@@ -22,7 +22,7 @@ a:hover, a:focus { color: #000; }
 ol { padding-left: 1.5em; }
 p { margin: 0 0 1em; }
 
-@media print { 
+@media print {
  body { width: 100%; }
  h1, h2, h3 { font-weight: bold; }
  a:after { content: ' <' attr(href) '>'; font-size: 90%; }


### PR DESCRIPTION
Noticed the font is set to Arial and _had_ to change it to try `Helvetica` first. Also thought the `sans-serif` fallback could be helpful, while we're at it...
