### PR TITLE
[pt-br]Remove promotion

### DIFF
--- a/lang/pt-BR/spec/v2.0.0-rc.1.md
+++ b/lang/pt-BR/spec/v2.0.0-rc.1.md
@@ -230,25 +230,7 @@ A Especificação da Semântica de Versionamento é autoria de [Tom
 Preston-Werner](http://tom.preston-werner.com), criador do Gravatars e 
 co-fundador do GitHub.
 
-A tradução deste documento para Português-Brasil foi iniciada de forma 
-colaborativa pela [Wend Tecnologia] (https://github.com/wendtecnologia) através
-de [Walker de Alencar Oliveira] (https://github.com/walkeralencar) e teve a 
-participação de:
-* [William G. Comnisky] (https://github.com/wcomnisky)
-* [Rafael Sirotheau] (https://github.com/rafasirotheau)
-* [Arthur Almeida] (https://github.com/arthuralmeidap)
-* [Alberto Guimarães Viana] (https://github.com/albertogviana)
-* [Rafael Lúcio] (https://github.com/poste9)
-* Josiel Rocha
-* Alessandro Leite
-* Vinícius Assef
-* [Silas Ribas Martins] (https://github.com/silasrm)
-
-Toda colaboração na tradução pode ser acompanhada no link:
-http://okfnpad.org/ep/pad/view/Fh9hjBPVu9/latest
-
-Caso queira deixar sua opinião, por favor [abra uma issue no GitHub]
-(https://github.com/wendtecnologia/semver/issues)
+Caso queira deixar sua opinião, por favor [abra uma issue no GitHub](https://github.com/mojombo/semver/issues).
 
 Licença
 -------

--- a/lang/pt-BR/spec/v2.0.0.md
+++ b/lang/pt-BR/spec/v2.0.0.md
@@ -269,25 +269,7 @@ A Especificação da Semântica de Versionamento é autoria de [Tom
 Preston-Werner](http://tom.preston-werner.com), criador do Gravatars e 
 co-fundador do GitHub.
 
-A tradução deste documento para Português-Brasil foi iniciada de forma 
-colaborativa pela [Wend Tecnologia](https://github.com/wendtecnologia) através
-de [Walker de Alencar Oliveira](https://github.com/walkeralencar) e teve a 
-participação de:
-
-* [William G. Comnisky](https://github.com/wcomnisky)
-* [Rafael Sirotheau](https://github.com/rafasirotheau)
-* [Arthur Almeida](https://github.com/arthuralmeidap)
-* [Alberto Guimarães Viana](https://github.com/albertogviana)
-* [Rafael Lúcio](https://github.com/poste9)
-* Josiel Rocha
-* Alessandro Leite
-* Vinícius Assef
-* [Silas Ribas Martins](https://github.com/silasrm)
-
-Toda colaboração na tradução pode ser acompanhada no link:
-http://pad.okfn.org/p/Fh9hjBPVu9
-
-Caso queira deixar sua opinião, por favor [abra uma issue no GitHub](https://github.com/wendtecnologia/semver/issues).
+Caso queira deixar sua opinião, por favor [abra uma issue no GitHub](https://github.com/mojombo/semver/issues).
 
 Licença
 -------


### PR DESCRIPTION
Important, if going to be merged, going after #96.

@walkeralencar, do you think it's ok to remove this part of translation?

My point it that none of the other translations (es, it, fr etc.) are informing the credits of translators at all.

I think the contributors/credits, in case of any need, could be get via git commit log (or GitHub contributors https://github.com/mojombo/semver.org/graphs/contributors), couldn't?
