### PR TITLE
Config option pygments deprecated

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,2 @@
 markdown: rdiscount
-pygments: true
+highlighter: pygments


### PR DESCRIPTION
This patch fixes deprecation warning about pygments config option when building semver.org. Deprecated 'pygments' configuration option has been renamed to 'highlighter'.
