### PR TITLE
Corrects issue #93, Title of 2.0.0-rc.2 is incoherent

### DIFF
--- a/spec/v2.0.0-rc.2.md
+++ b/spec/v2.0.0-rc.2.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Semantic Versioning 1.0.0-rc.2
+title: Semantic Versioning 2.0.0-rc.2
 ---
 
 Semantic Versioning 2.0.0-rc.2


### PR DESCRIPTION
Just a typo in the title text.
