### PR TITLE
[_layouts] Add link to german translation in cs and tr

### DIFF
--- a/_layouts/czech.html
+++ b/_layouts/czech.html
@@ -23,6 +23,7 @@
      <li><a lang="ar" rel="alternate" hreflang="ar" href="/lang/ar">العربية</a> [ar]</li>
      <li><a lang="ja" rel="alternate" hreflang="ja" href="/lang/ja">日本語</a> [ja]</li>
      <li><a lang="cs" rel="alternate" hreflang="cs" href="/lang/cs">česky</a> [cs]</li>
+     <li><a lang="de" rel="alternate" hreflang="de" href="/lang/de">deutsch</a> [de]</li>
    </ol>
    <ol class="nav">
     <li><a href="/lang/cs">v2.0.0</a></li>

--- a/_layouts/turkish.html
+++ b/_layouts/turkish.html
@@ -24,6 +24,7 @@
      <li><a lang="ja" rel="alternate" hreflang="ja" href="/lang/ja">日本語</a> [ja]</li>
      <li><a lang="tr" rel="alternate" hreflang="tr" href="/lang/tr">T&uuml;rk&ccedil;e</a> [tr]</li>
      <li><a lang="cs" rel="alternate" hreflang="cs" href="/lang/cs">česky</a> [cs]</li>
+     <li><a lang="de" rel="alternate" hreflang="de" href="/lang/de">deutsch</a> [de]</li>
    </ol>
    <ol class="nav">
      <li><a href="/lang/tr/spec/v2.0.0.html">v2.0.0</a></li>


### PR DESCRIPTION
Add missing link to german translation in `_layouts/czech.html` and `_layouts/turkish.html`.
