### PR TITLE
Change highlighter to rogue

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,2 @@
 markdown: kramdown
-pygments: true
+highlighter: rouge


### PR DESCRIPTION
Pygments is no longer supported on GitHub Pages.

https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors
