### PR TITLE
Sort translations by country code

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,8 @@
   </head>
   <body>
     <ol class="nav lang">
-      {% for language in site.languages %}
+      {% assign sorted_languages = site.languages | sort %}
+      {% for language in sorted_languages %}
         <li class="language language-{{ language[0] }}">
           <a rel="alternate" lang="{{ language[0] }}" hreflang="{{ language[0] }}"
             href="{{ language[0] | prepend: "/lang/" | prepend: site.github.url }}">

--- a/css/main.css
+++ b/css/main.css
@@ -42,6 +42,7 @@ ol.nav li {
   display: inline;
   font-weight: bold;
   margin-right: 20px;
+  white-space: nowrap;
 }
 
 ol.nav li a {


### PR DESCRIPTION
Previously translation links were presented in order they were added. Now they are sorted by country codes. This PR resolves #146.
