### PR TITLE
Fix wrong gender of « abîme »

### DIFF
--- a/lang/fr/spec/v2.0.0.md
+++ b/lang/fr/spec/v2.0.0.md
@@ -24,7 +24,7 @@ Introduction
 Dans le monde de la gestion des logiciels, il existe un endroit redouté appelé
 "l'enfer des dépendances" (de l'anglais "dependency hell"). Plus votre système se
 développe et plus vous intégrez de composants dans votre logiciel, plus vous êtes
-susceptible de vous trouver un jour dans cette abîme de désespoir.
+susceptible de vous trouver un jour dans cet abîme de désespoir.
 
 Dans les systèmes comportant de nombreuses dépendances, publier une nouvelle
 version d'un composant peut vite devenir un cauchemar. Si les règles de


### PR DESCRIPTION
The word « abîme » in French is masculine. Thus, one should write « cet abîme » instead of « cette abîme ».

**References:**

- [Wiktionary](https://fr.wiktionary.org/wiki/abîme)
- [ATILF](http://atilf.atilf.fr/dendien/scripts/tlfiv5/advanced.exe?8;s=1086297195;)