### PR TITLE
Use site-relative url for JavaScript source

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,6 +42,6 @@
     <div id="spec">
      {{ content }}
     </div>
-    <script src="{{ site.github.url }}/js/anchorli.js"></script>
+    <script src="/js/anchorli.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This used to render as `http://semver.org/js/anchorli.js`, which is rightfully rejected when the site is loaded via HTTPS and thus caused anchors to be missing.

This regressed in the following commit where the URL was changed to `{{ site.github.url }}/js/anchorli.js` instead of `/js/anchorli.js`. I'm not sure where this `site.github.url` value is defined (there's an entry in `_config_local.yml`, but I presume it's redundant and also empty).

https://github.com/semver/semver.org/commit/0fda15421a777e33fcb83453d8c0e0a8021e1f6d#diff-2c19d9859b055d0302043d0fa2833e3fR44

Closes https://github.com/semver/semver/issues/422.