### PR TITLE
_config.yml: Rename deprecated config option "gems" to "plugins"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ current_version: 2.0.0
 # Default author, for when none is set
 author: Tom Preston-Werner
 
-gems:
+plugins:
   - jekyll-sitemap
   - jekyll-seo-tag
   - jekyll-redirect-from


### PR DESCRIPTION
Warning was:
```
Configuration file: /app/_config.yml
       Deprecation: The 'gems' configuration option has been renamed
       to 'plugins'. Please update your config file accordingly.
```