### PR TITLE
_layouts: Fix overlong underline decoration

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,9 +15,8 @@
       {% for language in sorted_languages %}
         <li class="language language-{{ language[0] }}">
           <a rel="alternate" lang="{{ language[0] }}" hreflang="{{ language[0] }}"
-            href="{{ language[0] | prepend: "/lang/" }}">
-            {{ language[1] | smartify }} ({{ language[0] }})
-          </a>
+            href="{{ language[0] | prepend: "/lang/" }}"
+            >{{ language[1] | smartify }} ({{ language[0] }})</a>
         </li>
       {% endfor %}
     </ol>
@@ -32,9 +31,7 @@
         {% assign found = site.pages | where: "path", expected | first %}
         {% if found %}
           <li class="version version-{{ version }}">
-            <a href="{{ found.url }}">
-              {{ version}}
-            </a>
+            <a href="{{ found.url }}">{{ version}}</a>
           </li>
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
This pull request fixes the overlong underlines caused by HTML whitespace issues. Both Firefox and Chromium are affected. Please consider application.

![underlines](https://user-images.githubusercontent.com/1577132/51870879-21563180-2355-11e9-9327-3d25b13e6bda.png)