### PR TITLE
css: Make headlines stand out again, especially in FAQ

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -12,7 +12,7 @@ body { margin: 0 auto; padding: 0 10%; max-width: 710px; }
 @-ms-viewport { width: device-width; }
 html { -webkit-text-size-adjust: 100%; }
 
-h1, h2, h3 { text-align: center; font-weight: normal; }
+h1, h2, h3 { text-align: center; }
  h1 { font-size: 43px; margin: 1.1em 0 .7em; }
  h2 { margin: 2.1em 0 .7em; font-size: 24px; }
  h3 { text-align: left; font-size: 15.8px; margin-bottom: .6em; }


### PR DESCRIPTION
The current CSS takes away weight from headlines, which I consider a mistake, especially with the low visual distinction of questions and answers in the FAQ section.