### PR TITLE
Fix markdown link and replacing the URL for create issues.

### DIFF
--- a/lang/pt-BR/index.md
+++ b/lang/pt-BR/index.md
@@ -62,8 +62,7 @@ Especificação de Versionamento Semântico (SemVer)
 
 As palavras-chaves "DEVE", "NÃO DEVE", "OBRIGATÓRIO", "DEVERÁ", "NÃO DEVERÁ",
 "PODEM", "NÃO PODEM", "RECOMENDADO", "PODE" e "OPCIONAL" no presente 
-documento devem ser interpretados como descrito na [RFC 2119] 
-(http://tools.ietf.org/html/rfc2119).
+documento devem ser interpretados como descrito na [RFC 2119](http://tools.ietf.org/html/rfc2119).
 
 1. Software usando Versionamento Semântico DEVE declarar uma API pública. Esta 
 API poderá ser declarada no próprio código ou existir estritamente na 
@@ -287,7 +286,7 @@ participação de:
 Toda colaboração na tradução pode ser acompanhada no link:
 http://pad.okfn.org/p/Fh9hjBPVu9
 
-Caso queira deixar sua opinião, por favor [abra uma issue no GitHub](https://github.com/wendtecnologia/semver/issues).
+Caso queira deixar sua opinião, por favor [abra uma issue no GitHub](https://github.com/semver/semver.org/issues).
 
 Licença
 -------

--- a/lang/pt-BR/index.md
+++ b/lang/pt-BR/index.md
@@ -286,7 +286,7 @@ participação de:
 Toda colaboração na tradução pode ser acompanhada no link:
 http://pad.okfn.org/p/Fh9hjBPVu9
 
-Caso queira deixar sua opinião, por favor [abra uma issue no GitHub](https://github.com/semver/semver.org/issues).
+Caso queira deixar sua opinião, por favor [abra uma issue no GitHub](https://github.com/mojombo/semver/issues).
 
 Licença
 -------


### PR DESCRIPTION
Hello ✋ 

This PR fix the link for RFC 2119 and change the URL for creating new issues.

The link was changed because that repository does not have attention enough. This problem related about the RFC link was reported 4 years ago ([reference](https://github.com/wendtecnologia/semver/issues/9)) and the PR submitted last month ([reference](https://github.com/wendtecnologia/semver/pull/12)), neither of them was answered. So I think it's better to create news issues related about portuguese translation here.