### PR TITLE
[Japanese] Update Japanese specification to follow up to 2.0.0

### DIFF
--- a/lang/ja/index.md
+++ b/lang/ja/index.md
@@ -181,7 +181,7 @@ FAQ
 
 ### SemVer文字列をチェックするために推奨される正規表現（RegEx）はありますか？
 
-　二つあります。一つは名前付きグループをサポートするシステム（PCRE [Perl Compatible Regular Expressions, i.e. Perl, PHP and R]、Python、Go）のための正規表現です。
+　二つあります。一つは名前付きグループをサポートするシステム（PCRE [Perl Compatible Regular Expressions, 例: Perl, PHP and R]、Python、Go）のための正規表現です。
 
 参考: <https://regex101.com/r/Ly7O1x/3/>
 
@@ -189,7 +189,7 @@ FAQ
 ^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
 ```
 
-　もう一つは番号付きキャプチャグループを使った正規表現です（したがって、cg1 = メジャー、cg2 = マイナー、cg3 = パッチ、cg4 = プレリリース、cg5 = ビルドメタデータを意味します）。これはECMA Script（JavaScript）、PCRE（Perl Compatible Regular Expressions, i.e. Perl, PHP and R）、Python、Goにおいて互換性があります。
+　もう一つは番号付きキャプチャグループを使った正規表現です（したがって、cg1 = メジャー、cg2 = マイナー、cg3 = パッチ、cg4 = プレリリース、cg5 = ビルドメタデータを意味します）。これはECMA Script（JavaScript）、PCRE（Perl Compatible Regular Expressions, 例: Perl, PHP and R）、Python、Goにおいて互換性があります。
 
 参考: <https://regex101.com/r/vkijKf/1/>
 

--- a/lang/ja/index.md
+++ b/lang/ja/index.md
@@ -33,13 +33,13 @@ language: ja
 
 　この文書における各キーワード「しなければならない（MUST）」、「してはならない（MUST NOT）」、「要求されている（REQUIRED）」、「することになる（SHALL）」、「することはない（SHALL NOT）」、「する必要がある（SHOULD）」、「しないほうがよい（SHOULD NOT）」、「推奨される（RECOMMENDED）」、「してもよい（MAY）」、「選択できる（OPTIONAL）」は、[RFC 2119](http://tools.ietf.org/html/rfc2119)に記載されている内容に従い解釈してください。
 
-1. セマンティック バージョニングを適用するソフトウェアはパブリックAPIを宣言しなければなりません（MUST）。このAPIはコード自体で表現されているかもしれませんし、明確に文書として存在してるかもしれません。どちらにせよ、正確かつ漏れがないようにするべきです。
+1. セマンティック バージョニングを適用するソフトウェアはパブリックAPIを宣言しなければなりません（MUST）。このAPIはコード自体で表現されているかもしれませんし、明確に文書として存在してるかもしれません。どちらにせよ、正確かつ漏れがないようにするべきです（SHOULD）。
 
 2. 通常のバージョンナンバーは、X.Y.Zの形式にしなければなりません（MUST）。このときX、Y、Zは非負の整数であり（MUST）、各数値の先頭にゼロを配置してはなりません（MUST NOT）。Xはメジャーバージョン、Yはマイナーバージョン、Zはパッチバージョンを表します。各バージョンは数値的にバージョンアップしなければなりません（MUST）。例：1.9.0 -> 1.10.0 -> 1.11.0。
 
 3. 一度パッケージをリリースしたのなら、そのバージョンのパッケージのコンテンツは修正してはなりません（MUST NOT）。いかなる修正も新しいバージョンとしてリリースしなければなりません（MUST）。
 
-4. メジャーバージョンのゼロ（0.y.z）は初期段階の開発用です。いつでも、いかなる変更も起こりえます。この時のパブリックAPIは安定していると考えるべきではありません。
+4. メジャーバージョンのゼロ（0.y.z）は初期段階の開発用です。いつでも、いかなる変更も起こりえます（MAY）。この時のパブリックAPIは安定していると考えるべきではありません（SHOULD NOT）。
 
 5. バージョン1.0.0はパブリックAPIを定義します。このリリース後のバージョンナンバーの上げ方に関しては、パブリックAPIがどのくらい変更されるのかによって決まります。
 
@@ -51,9 +51,74 @@ language: ja
 
 9. プレリリースバージョンは、パッチバージョンの直後にハイフンとドットで区切られた識別子を追加することで表現してもよいです（MAY）。識別子は必ずASCII英数字とハイフン [0-9A-Za-z-] でなければなりません（MUST）。識別子は空であってはなりません（MUST NOT）。数値の識別子はゼロから始めてはなりません（MUST NOT）。プレリリースバージョンは関連する通常のバージョンよりも低い優先度です。プレリリースバージョンは、不安定であり、関連する通常のバージョンが示す要件と互換性を満たさない可能性があります。例：1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92。
 
-10. ビルドメタデータはパッチまたはプレリリースバージョンの直後にプラス記号とドットで区切られた識別子を追加することで表現してもよいです（MAY）。識別子は必ずASCII英数字とハイフン [0-9A-Za-z-] でなければなりません（MUST）。識別子は空であってはなりません（MUST NOT）。バージョンの優先度を決める際にはビルドメタデータは無視されるべきです（SHOULD）。つまり、2つのビルドメタデータだけが違うバージョンは、同じ優先度ということです。例：1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85。
+10. ビルドメタデータはパッチまたはプレリリースバージョンの直後にプラス記号とドットで区切られた識別子を追加することで表現してもよいです（MAY）。識別子は必ずASCII英数字とハイフン [0-9A-Za-z-] でなければなりません（MUST）。識別子は空であってはなりません（MUST NOT）。バージョンの優先度を決める際にはビルドメタデータは無視されなければなりません（MUST）。つまり、2つのビルドメタデータだけが違うバージョンは、同じ優先度ということです。例：1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85。
 
 11. バージョン同士をどのように比較するのかは優先度によって決まります。優先度はメジャー、マイナー、パッチ、プレリリース識別子の順番（ビルドメタデータは優先度に関して考慮しない）で分けて評価されなければなりません（MUST）。優先度は、各識別子を左から右に比較して最初の違いによって評価します。以下のように、メジャー、マイナー、パッチバージョンと常に数値的に比較します。例：1.0.0 < 2.0.0 < 2.1.0 < 2.1.1。メジャー、マイナー、パッチが同じ場合、プレリリースバージョンを持っている方が通常のバージョンよりも低い優先度です。例：1.0.0-alpha < 1.0.0。同じ、メジャー、マイナー、パッチを持つプレリリースバージョンの優先度の決定は、ドットで区切れた識別子を左から右に、異なるところが見つかるまで比較し決定しなければなりません（MUST）。数値のみで構成される識別子は数値的に比較され、文字列やハイフンを含む識別子はASCIIソート順に辞書的に比較されます。数値的な識別子は常に数値的でない識別子よりも低い優先度です。もし先行する識別子が同じ場合、プレリリースのフィールドが小さいセットよりも大きいセットのほうが高い優先度です。例：1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0。
+
+SemVerバージョンを表すバッカス・ナウア記法
+--------------------------------------------------
+
+    <valid semver> ::= <version core>
+                     | <version core> "-" <pre-release>
+                     | <version core> "+" <build>
+                     | <version core> "-" <pre-release> "+" <build>
+
+    <version core> ::= <major> "." <minor> "." <patch>
+
+    <major> ::= <numeric identifier>
+
+    <minor> ::= <numeric identifier>
+
+    <patch> ::= <numeric identifier>
+
+    <pre-release> ::= <dot-separated pre-release identifiers>
+
+    <dot-separated pre-release identifiers> ::= <pre-release identifier>
+                                              | <pre-release identifier> "." <dot-separated pre-release identifiers>
+
+    <build> ::= <dot-separated build identifiers>
+
+    <dot-separated build identifiers> ::= <build identifier>
+                                        | <build identifier> "." <dot-separated build identifiers>
+
+    <pre-release identifier> ::= <alphanumeric identifier>
+                               | <numeric identifier>
+
+    <build identifier> ::= <alphanumeric identifier>
+                         | <digits>
+
+    <alphanumeric identifier> ::= <non-digit>
+                                | <non-digit> <identifier characters>
+                                | <identifier characters> <non-digit>
+                                | <identifier characters> <non-digit> <identifier characters>
+
+    <numeric identifier> ::= "0"
+                           | <positive digit>
+                           | <positive digit> <digits>
+
+    <identifier characters> ::= <identifier character>
+                              | <identifier character> <identifier characters>
+
+    <identifier character> ::= <digit>
+                             | <non-digit>
+
+    <non-digit> ::= <letter>
+                  | "-"
+
+    <digits> ::= <digit>
+               | <digit> <digits>
+
+    <digit> ::= "0"
+              | <positive digit>
+
+    <positive digit> ::= "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+
+    <letter> ::= "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J"
+               | "K" | "L" | "M" | "N" | "O" | "P" | "Q" | "R" | "S" | "T"
+               | "U" | "V" | "W" | "X" | "Y" | "Z" | "a" | "b" | "c" | "d"
+               | "e" | "f" | "g" | "h" | "i" | "j" | "k" | "l" | "m" | "n"
+               | "o" | "p" | "q" | "r" | "s" | "t" | "u" | "v" | "w" | "x"
+               | "y" | "z"
 
 
 なぜセマンティック バージョニングを使用するのか？
@@ -106,17 +171,39 @@ FAQ
 
 　既存機能を廃止予定にするのはソフトウェア開発においては普通の事であり、開発を進める上で頻繁に必要となります。パブリックAPIの一部を非推奨にしたい場合、2つのことをすべきです。第一にユーザーに知らせるためにドキュメントを更新して下さい。次に非推奨機能を残したまま新しいマイナーバージョンをリリースして下さい。完全に非推奨機能を削除しメジャーバージョンをリリースする前に、ユーザーがスムーズに新しいAPIに移行できるように少なくとも1回のマイナーバージョン（非推奨機能を含んだ）をリリースして下さい。
 
-### semverのバージョン文字列に限度はありますか？
+### SemVerのバージョン文字列に限度はありますか？
 
 　いいえ、ありませんが良識ある判断をしてください。例えば255文字のバージョン文字列は過剰と言えるでしょうし、特定のシステムではそれ独自の文字列の限界値があることでしょう。
+
+### 『v1.2.3』はセマンティック バージョンでしょうか？
+
+　いいえ、『v1.2.3』はセマンティック バージョンではありません。しかしながら、セマンティック バージョンに接頭辞の『v』を付けるのは英語ではバージョン番号であることを示す一般的な方法です。バージョン管理では、『バージョン』を『v』と略すことがよくあります。たとえば `git tag v1.2.3 -m" Release version 1.2.3 "` では『v1.2.3』はタグ名であり、セマンティック バージョンは『1.2.3』です。
+
+### SemVer文字列をチェックするために推奨される正規表現（RegEx）はありますか？
+
+　二つあります。一つは名前付きグループをサポートするシステム（PCRE [Perl Compatible Regular Expressions, i.e. Perl, PHP and R]、Python、Go）のための正規表現です。
+
+参考: <https://regex101.com/r/Ly7O1x/3/>
+
+```
+^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+```
+
+　もう一つは番号付きキャプチャグループを使った正規表現です（したがって、cg1 = メジャー、cg2 = マイナー、cg3 = パッチ、cg4 = プレリリース、cg5 = ビルドメタデータを意味します）。これはECMA Script（JavaScript）、PCRE（Perl Compatible Regular Expressions, i.e. Perl, PHP and R）、Python、Goにおいて互換性があります。
+
+参考: <https://regex101.com/r/vkijKf/1/>
+
+```
+^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+```
 
 
 著者について
 -----
 
-セマンティック バージョニング仕様書の著者は[Tom Preston-Werner](http://tom.preston-werner.com/)氏です。彼はGravatarsの考案者であり、GitHubの共同創設者でもあります。
+セマンティック バージョニング仕様書の著者は[Tom Preston-Werner](http://tom.preston-werner.com/)氏です。彼はGravatarの考案者であり、GitHubの共同創設者でもあります。
 
-もしフィードバックがある場合は、[GitHub上でissueを立てて下さい](https://github.com/mojombo/semver/issues)。
+もしフィードバックがある場合は、[GitHub上でissueを立てて下さい](https://github.com/semver/semver/issues)。
 
 ライセンス
 -------

--- a/lang/ja/spec/v2.0.0.md
+++ b/lang/ja/spec/v2.0.0.md
@@ -33,13 +33,13 @@ language: ja
 
 　この文書における各キーワード「しなければなりません（MUST）」、「してはなりません（MUST NOT）」、「要求されている（REQUIRED）」、「することになる(SHALL)」、「することはない（SHALL NOT）」、「する必要がある（SHOULD）」、「しないほうがよい（SHOULD NOT）」、「推奨される（RECOMMENDED）」、「してもよい（MAY）」、「選択できる（OPTIONAL）」は、[RFC 2119](http://tools.ietf.org/html/rfc2119)に記載されている内容に従い解釈してください。
 
-1. セマンティック バージョニングを適用するソフトウェアはパブリックAPIを宣言しなければなりません（MUST）。このAPIはコード自体で表現されているかもしれませんし、明確に文書として存在してるかもしれません。どちらにせよ、正確かつ漏れがないようにするべきです。
+1. セマンティック バージョニングを適用するソフトウェアはパブリックAPIを宣言しなければなりません（MUST）。このAPIはコード自体で表現されているかもしれませんし、明確に文書として存在してるかもしれません。どちらにせよ、正確かつ漏れがないようにするべきです（SHOULD）。
 
 2. 通常のバージョンナンバーは、X.Y.Zの形式にしなければなりません（MUST）。このときX、Y、Zは負の整数であってはならず、各数値の先頭にゼロを配置してはなりません（MUST NOT）。Xはメジャーバージョン、Yはマイナーバージョン、Zはパッチバージョンを表します。各バージョンは数値的にバージョンアップしなければなりません（MUST）。例：1.9.0 -> 1.10.0 -> 1.11.0。
 
 3. 一度パッケージをリリースしたのなら、そのバージョンのパッケージのコンテンツは修正してはなりません（MUST NOT）。いかなる修正も新しいバージョンとしてリリースしなければなりません（MUST）。
 
-4. メジャーバージョンのゼロ（0.y.z）は初期段階の開発用です。いつでも、いかなる変更も起こりうります。この時のパブリックAPIは安定していると考えるべきではありません。
+4. メジャーバージョンのゼロ（0.y.z）は初期段階の開発用です。いつでも、いかなる変更も起こりうります（MAY）。この時のパブリックAPIは安定していると考えるべきではありません（SHOULD NOT）。
 
 5. バージョン1.0.0でパブリックAPIを定義します。このリリース後のバージョンナンバーの上げ方に関しては、パブリックAPIがどのくらい変更されるのかによって決まります。
 
@@ -51,9 +51,74 @@ language: ja
 
 9. プレリリースバージョンは、パッチバージョンの直後にハイフンとドットで区切られた識別子を追加することで表現してもよいです（MAY）。識別子は必ずASCII英数字とハイフン[0-9A-Za-z-]でなければなりません（MUST）。識別子は空であってはなりません（MUST NOT）。数値の識別子はゼロからは始めてはなりません（MUST NOT）。プレリリースバージョンは関連する通常のバージョンよりも低い優先度です。プレリリースバージョンは、不安定であり、関連する通常バージョンが示す要件と互換性を満たさない可能性があります。例：1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92。
 
-10. ビルドメタデータはパッチもしくはプレリリースバージョンの直後にプラス記号とドットで区切られた識別子を追加することで表現してもよいです（MAY）。識別子は必ずASCII英数字とハイフン[0-9A-Za-z-]でなければなりません（MUST）。識別子は空であってはなりません（MUST NOT）。バージョンの優先度を決める際にはビルドメタデータは無視されるべきです（SHOULD）。つまり、2つのビルドメタデータだけが違うバージョンは、同じ優先度ということです。例：1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85。
+10. ビルドメタデータはパッチもしくはプレリリースバージョンの直後にプラス記号とドットで区切られた識別子を追加することで表現してもよいです（MAY）。識別子は必ずASCII英数字とハイフン[0-9A-Za-z-]でなければなりません（MUST）。識別子は空であってはなりません（MUST NOT）。バージョンの優先度を決める際にはビルドメタデータは無視されなければなりません（MUST）。つまり、2つのビルドメタデータだけが違うバージョンは、同じ優先度ということです。例：1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85。
 
 11. バージョン同士をどのように比較するのかは優先度によって決まります。優先度はメジャー、マイナー、パッチ、プレリリース識別子の順番（ビルドメタデータは優先度に関して考慮しない）で分けて評価されなければなりません（MUST）。優先度は、各識別子を左から右に比較して最初の違いによって評価します。以下のように、メジャー、マイナー、パッチバージョンと常に数値的に比較します。例：1.0.0 < 2.0.0 < 2.1.0 < 2.1.1。 メジャー、マイナー、パッチが同じ場合、プレリリースバージョンを持っている方が通常のバージョンよりも低い優先度です。例：1.0.0-alpha < 1.0.0。 同じ、メジャー、マイナー、パッチを持つプレリリースバージョンの優先度の決定は、ドットで区切れた識別子を左から右に、異なるところが見つかるまで比較し決定しなければなりません（MUST）。数値のみで構成される識別子は数値的に比較され、文字列やハイフンを含む識別子はASCIIソート順に辞書的に比較されます。数値的な識別子は常に非数値的な識別子よりも低い優先度です。もし先行する識別子が同じ場合、プレリリースのフィールドが小さいセットよりも大きいセットのほうが高い優先度です。例：1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0。
+
+SemVerバージョンを表すバッカス・ナウア記法
+--------------------------------------------------
+
+    <valid semver> ::= <version core>
+                     | <version core> "-" <pre-release>
+                     | <version core> "+" <build>
+                     | <version core> "-" <pre-release> "+" <build>
+
+    <version core> ::= <major> "." <minor> "." <patch>
+
+    <major> ::= <numeric identifier>
+
+    <minor> ::= <numeric identifier>
+
+    <patch> ::= <numeric identifier>
+
+    <pre-release> ::= <dot-separated pre-release identifiers>
+
+    <dot-separated pre-release identifiers> ::= <pre-release identifier>
+                                              | <pre-release identifier> "." <dot-separated pre-release identifiers>
+
+    <build> ::= <dot-separated build identifiers>
+
+    <dot-separated build identifiers> ::= <build identifier>
+                                        | <build identifier> "." <dot-separated build identifiers>
+
+    <pre-release identifier> ::= <alphanumeric identifier>
+                               | <numeric identifier>
+
+    <build identifier> ::= <alphanumeric identifier>
+                         | <digits>
+
+    <alphanumeric identifier> ::= <non-digit>
+                                | <non-digit> <identifier characters>
+                                | <identifier characters> <non-digit>
+                                | <identifier characters> <non-digit> <identifier characters>
+
+    <numeric identifier> ::= "0"
+                           | <positive digit>
+                           | <positive digit> <digits>
+
+    <identifier characters> ::= <identifier character>
+                              | <identifier character> <identifier characters>
+
+    <identifier character> ::= <digit>
+                             | <non-digit>
+
+    <non-digit> ::= <letter>
+                  | "-"
+
+    <digits> ::= <digit>
+               | <digit> <digits>
+
+    <digit> ::= "0"
+              | <positive digit>
+
+    <positive digit> ::= "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+
+    <letter> ::= "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J"
+               | "K" | "L" | "M" | "N" | "O" | "P" | "Q" | "R" | "S" | "T"
+               | "U" | "V" | "W" | "X" | "Y" | "Z" | "a" | "b" | "c" | "d"
+               | "e" | "f" | "g" | "h" | "i" | "j" | "k" | "l" | "m" | "n"
+               | "o" | "p" | "q" | "r" | "s" | "t" | "u" | "v" | "w" | "x"
+               | "y" | "z"
 
 
 なぜセマンティック バージョニングを使用するのか？
@@ -106,17 +171,39 @@ FAQ
 
 　既存機能を廃止予定にするのはソフトウェア開発においては普通の事であり、開発を進める上で頻繁に必要となります。パブリックAPIの一部を非推奨にしたい場合、2つのことをすべきです。第一にユーザーに知らせるためにドキュメントを更新して下さい。次に非推奨機能を残したまま新しいマイナーバージョンをリリースして下さい。完全に非推奨機能を削除しメジャーバージョンをリリースする前に、ユーザーがスムーズに新しいAPIに移行できるように少なくとも1回のマイナーバージョン（非推奨機能を含んだ）をリリースして下さい。
 
-### semverのバージョン文字列に限度はありますか？
+### SemVerのバージョン文字列に限度はありますか？
 
-　いいえ、ありませんが良識ある判断をしてください。例えば255文字数のバージョン文字列は過剰と言えるでしょうし、特定のシステムではそれ独自の文字列の限界値があることでしょう。
+　いいえ、ありませんが良識ある判断をしてください。例えば255文字のバージョン文字列は過剰と言えるでしょうし、特定のシステムではそれ独自の文字列の限界値があることでしょう。
+
+### 『v1.2.3』はセマンティック バージョンでしょうか？
+
+　いいえ、『v1.2.3』はセマンティック バージョンではありません。しかしながら、セマンティック バージョンに接頭辞の『v』を付けるのは英語ではバージョン番号であることを示す一般的な方法です。バージョン管理では、『バージョン』を『v』と略すことがよくあります。たとえば `git tag v1.2.3 -m" Release version 1.2.3 "` では『v1.2.3』はタグ名であり、セマンティック バージョンは『1.2.3』です。
+
+### SemVer文字列をチェックするために推奨される正規表現（RegEx）はありますか？
+
+　二つあります。一つは名前付きグループをサポートするシステム（PCRE [Perl Compatible Regular Expressions, i.e. Perl, PHP and R]、Python、Go）のための正規表現です。
+
+参考: <https://regex101.com/r/Ly7O1x/3/>
+
+```
+^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+```
+
+　もう一つは番号付きキャプチャグループを使った正規表現です（したがって、cg1 = メジャー、cg2 = マイナー、cg3 = パッチ、cg4 = プレリリース、cg5 = ビルドメタデータを意味します）。これはECMA Script（JavaScript）、PCRE（Perl Compatible Regular Expressions, i.e. Perl, PHP and R）、Python、Goにおいて互換性があります。
+
+参考: <https://regex101.com/r/vkijKf/1/>
+
+```
+^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+```
 
 
 著者について
 -----
 
-セマンティック バージョニング仕様書の著者は[Tom Preston-Werner](http://tom.preston-werner.com/)氏です。彼はGravatarsの考案者であり、GitHubの共同創設者でもあります。
+セマンティック バージョニング仕様書の著者は[Tom Preston-Werner](http://tom.preston-werner.com/)氏です。彼はGravatarの考案者であり、GitHubの共同創設者でもあります。
 
-もしフィードバックがある場合は、[GitHub上でissueを立てて下さい](https://github.com/mojombo/semver/issues)。
+もしフィードバックがある場合は、[GitHub上でissueを立てて下さい](https://github.com/semver/semver/issues)。
 
 ライセンス
 -------

--- a/lang/ja/spec/v2.0.0.md
+++ b/lang/ja/spec/v2.0.0.md
@@ -181,7 +181,7 @@ FAQ
 
 ### SemVer文字列をチェックするために推奨される正規表現（RegEx）はありますか？
 
-　二つあります。一つは名前付きグループをサポートするシステム（PCRE [Perl Compatible Regular Expressions, i.e. Perl, PHP and R]、Python、Go）のための正規表現です。
+　二つあります。一つは名前付きグループをサポートするシステム（PCRE [Perl Compatible Regular Expressions, 例: Perl, PHP and R]、Python、Go）のための正規表現です。
 
 参考: <https://regex101.com/r/Ly7O1x/3/>
 
@@ -189,7 +189,7 @@ FAQ
 ^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
 ```
 
-　もう一つは番号付きキャプチャグループを使った正規表現です（したがって、cg1 = メジャー、cg2 = マイナー、cg3 = パッチ、cg4 = プレリリース、cg5 = ビルドメタデータを意味します）。これはECMA Script（JavaScript）、PCRE（Perl Compatible Regular Expressions, i.e. Perl, PHP and R）、Python、Goにおいて互換性があります。
+　もう一つは番号付きキャプチャグループを使った正規表現です（したがって、cg1 = メジャー、cg2 = マイナー、cg3 = パッチ、cg4 = プレリリース、cg5 = ビルドメタデータを意味します）。これはECMA Script（JavaScript）、PCRE（Perl Compatible Regular Expressions, 例: Perl, PHP and R）、Python、Goにおいて互換性があります。
 
 参考: <https://regex101.com/r/vkijKf/1/>
 


### PR DESCRIPTION
Compared to the original English document, I found that the Japanese one lacks some parts and there are some differences.

This commit makes Japanese specification follow up to https://github.com/semver/semver.org/commit/b5e2e75374611657c0c62e0bcc8d03172d49e3d5.