### PR TITLE
Fix typo in german translation

### DIFF
--- a/lang/de/spec/v2.0.0.md
+++ b/lang/de/spec/v2.0.0.md
@@ -104,7 +104,7 @@ Dies würde als kompatibel angesehen werden, da es die öffentliche API nicht be
 
 ### Was soll ich tun wenn ich die öffentliche API versehentlich derartig verändert habe, dass sie nicht mit der Änderung an der Versionsnummer harmoniert (Das heißt, der Code zerstört fälschlicherweise in einer Patch Version die API-Konformität)?
 
-Entscheide nach deinem eigene Ermessen. Wenn du eine große Nutzergemeinde hast, die von der aktuellen API stark abhängt, dann wäre es wahrscheinlich das Beste, die Veröffentlichung als eine Major Version zu publizieren, auch wenn die Änderungen eigentlich nur einen Patch darstellen sollten. Denk dran, bei *Semantic Versioning* dreht sich alles darum, die Art und den Umfang der Änderungen am Code durch die Änderungen an der Versionsnummer zu vermitteln.
+Entscheide nach deinem eigenen Ermessen. Wenn du eine große Nutzergemeinde hast, die von der aktuellen API stark abhängt, dann wäre es wahrscheinlich das Beste, die Veröffentlichung als eine Major Version zu publizieren, auch wenn die Änderungen eigentlich nur einen Patch darstellen sollten. Denk dran, bei *Semantic Versioning* dreht sich alles darum, die Art und den Umfang der Änderungen am Code durch die Änderungen an der Versionsnummer zu vermitteln.
 
 ### Wie soll ich mit *deprecated* Funktionen verfahren?
 


### PR DESCRIPTION
Fix typo: `eigene Ermessen` -> `eigenen Ermessen`