### PR TITLE
Added script to automatically sync between original - website repos 

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,14 +1,13 @@
 name: Nightly Sync of content
 
-# on:
-#   schedule:
-#   - cron: '0 3 * * *' # run daily at 3am
-on: [issue_comment]
+on:
+  schedule:
+  - cron: '0 3 * * *' # run daily at 3am
 
 
 jobs:
   sync:
-    if: github.repository == 'alexandrtovmach/semver.org'
+    if: github.repository == 'semver/semver.org'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,38 @@
+name: Nightly Sync of content
+
+# on:
+#   schedule:
+#   - cron: '0 3 * * *' # run daily at 3am
+on: [issue_comment]
+
+
+jobs:
+  sync:
+    if: github.repository == 'semver/semver'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install
+        run: npm ci
+
+      - name: Collect latest releases
+        run: npm run collect
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v2
+        with:
+          commit-message: 'feat: Updated SemVer spec'
+          title: Original specification updates
+          body: Auto-generated PR with specification updates from [semver/semver](https://github.com/semver/semver) repo. Please close this PR and immediately re-open it to trigger check run. More details in ["Triggering further workflow runs"](https://github.com/peter-evans/create-pull-request/blob/master/docs/concepts-guidelines.md#triggering-further-workflow-runs).

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -8,7 +8,7 @@ on: [issue_comment]
 
 jobs:
   sync:
-    if: github.repository == 'semver/semver'
+    if: github.repository == 'alexandrtovmach/semver.org'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site
 Gemfile.lock
 
 .idea/
+node_modules/

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,5 @@
 title: Semantic Versioning
 descriptions: A simple set of rules and requirements that dictate how version numbers are assigned and incremented
-
-# Should be in the form of
-# <machine readable key>: <human readable label>
 languages:
   en: english
   fr: français
@@ -32,27 +29,20 @@ languages:
   ca: català
   hu: magyar
   hy: Հայերեն
-
 versions:
   - 2.0.0
   - 2.0.0-rc.2
   - 2.0.0-rc.1
   - 1.0.0
   - 1.0.0-beta
-
 current_version: 2.0.0
-
-# Default author, for when none is set
 author: Tom Preston-Werner
-
 plugins:
   - jekyll-sitemap
   - jekyll-seo-tag
   - jekyll-redirect-from
-
 defaults:
-  -
-    scope:
-      path: ""
+  - scope:
+      path: ''
     values:
-      layout: "default"
+      layout: default

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "semver.org",
+  "version": "0.0.1",
+  "lockfileVersion": 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,45 @@
 {
   "name": "semver.org",
   "version": "0.0.1",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Website for SemVer specification https://semver.org",
   "main": "scripts/collect.js",
   "scripts": {
+    "collect": "node scripts/collect.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "semver.org",
+  "version": "0.0.1",
+  "description": "Website for SemVer specification https://semver.org",
+  "main": "scripts/collect.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/semver/semver.org.git"
+  },
+  "keywords": [
+    "semver",
+    "spec",
+    "version",
+    "semantic",
+    "version"
+  ],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/semver/semver.org/issues"
+  },
+  "homepage": "https://github.com/semver/semver.org#readme",
+  "dependencies": {}
+}

--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
     "url": "https://github.com/semver/semver.org/issues"
   },
   "homepage": "https://github.com/semver/semver.org#readme",
-  "dependencies": {}
+  "dependencies": {},
+  "devDependencies": {
+    "js-yaml": "^3.14.0",
+    "semver": "^7.3.2"
+  }
 }

--- a/scripts/collect.js
+++ b/scripts/collect.js
@@ -1,0 +1,97 @@
+const { promises: fs } = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const REPO_LINK = "https://github.com/semver/semver.git";
+const ORIGINAL_DIR = path.resolve(__dirname, "semver");
+const ORIGINAL_FILE = path.resolve(ORIGINAL_DIR, "semver.md");
+const TARGET_DIR = path.resolve(__dirname, "../spec");
+
+const cloneRepository = (repoLink, targetPath) =>
+  execSync(`git clone ${repoLink}`, {
+    stdio: [0, 1, 2],
+    cwd: path.resolve(__dirname, targetPath || ""),
+  });
+
+const parseVersion = async (filePath) => {
+  const content = await fs.readFile(filePath, "utf8");
+  return content.match(/Semantic Versioning (.+)\n/)[1];
+};
+
+const collect = async () => {
+  await cloneRepository(REPO_LINK);
+  const version = await parseVersion(ORIGINAL_FILE);
+  await fs.copyFile(ORIGINAL_FILE, path.resolve(TARGET_DIR, `v${version}.md`));
+  await fs.rmdir(ORIGINAL_DIR, { recursive: true });
+};
+
+collect();
+
+// const download = require("download");
+// const walk = require("walk-sync");
+// const { difference } = require("lodash");
+
+// const getVersions = require("./getVersions");
+// const { supportedVersions } = require("../package.json");
+
+// const contentDir = path.join(__dirname, "content");
+// const originalSourceLocale = "en-US";
+
+// collect();
+
+// async function collect() {
+//   const nodeVersions = await getVersions(supportedVersions);
+//   for (const major in nodeVersions) {
+//     const version = nodeVersions[major];
+//     await getDocsForNodeVersion(major, version).catch((err) => {
+//       console.error(`problem fetching version: ${version}`);
+//       console.error(err);
+//     });
+//   }
+// }
+
+// async function getDocsForNodeVersion(major, version) {
+//   const docDir = path.join(contentDir, major, originalSourceLocale);
+//   const downloadOptions = {
+//     extract: true,
+//     strip: 1,
+//     filter: (file) =>
+//       path.extname(file.path) === ".md" && file.path.startsWith("doc"),
+//   };
+
+//   // clean out english translations to ensure old files are removed
+//   fs.remove(docDir);
+
+//   // download repo bundle and extract
+//   const tarballUrl = `https://github.com/semver/semver/archive/${version}.tar.gz`;
+//   console.log("downloading", tarballUrl);
+//   await download(tarballUrl, docDir, downloadOptions);
+//   await cleanupTranslations(major);
+// }
+
+// const cleanupTranslations = async (version) => {
+//   const languages = fs.readdirSync(path.join(contentDir, version));
+//   const originalPath = path.join(
+//     contentDir,
+//     version,
+//     originalSourceLocale,
+//     "doc"
+//   );
+//   const originalFiles = walk(originalPath, { directories: false });
+//   await Promise.all(
+//     languages.map((language) => {
+//       const translatedPath = path.join(contentDir, version, language, "doc");
+//       const translatedFiles = walk(translatedPath, {
+//         directories: false,
+//       });
+//       const translatedOriginDiff = difference(translatedFiles, originalFiles);
+//       return Promise.all(
+//         translatedOriginDiff.map((filePath) => {
+//           const fileToRemovePath = path.join(translatedPath, filePath);
+//           console.log("Removed:", fileToRemovePath);
+//           return fs.remove(fileToRemovePath);
+//         })
+//       );
+//     })
+//   );
+// };

--- a/scripts/collect.js
+++ b/scripts/collect.js
@@ -1,11 +1,14 @@
 const { promises: fs } = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
+const yaml = require("js-yaml");
+const semver = require('semver')
 
 const REPO_LINK = "https://github.com/semver/semver.git";
 const ORIGINAL_DIR = path.resolve(__dirname, "semver");
 const ORIGINAL_FILE = path.resolve(ORIGINAL_DIR, "semver.md");
 const TARGET_DIR = path.resolve(__dirname, "../spec");
+const CONFIG_FILE = path.resolve(__dirname, "../_config.yml");
 
 const cloneRepository = (repoLink, targetPath) =>
   execSync(`git clone ${repoLink}`, {
@@ -18,80 +21,25 @@ const parseVersion = async (filePath) => {
   return content.match(/Semantic Versioning (.+)\n/)[1];
 };
 
+const checkOrUpdateYaml = async (originalVersion) => {
+  const yamlConfig = await fs.readFile(CONFIG_FILE);
+  const config = yaml.safeLoad(yamlConfig);
+  if (!config.versions.includes(originalVersion)) {
+    config.versions = [originalVersion, ...config.versions];
+  }
+  if (semver.gt(originalVersion, config.current_version)) {
+    config.current_version = originalVersion;
+  }
+  const updatedYamlConfig = yaml.safeDump(config, { lineWidth: 120 });
+  return fs.writeFile(CONFIG_FILE, updatedYamlConfig);
+};
+
 const collect = async () => {
-  await cloneRepository(REPO_LINK);
+  cloneRepository(REPO_LINK);
   const version = await parseVersion(ORIGINAL_FILE);
   await fs.copyFile(ORIGINAL_FILE, path.resolve(TARGET_DIR, `v${version}.md`));
   await fs.rmdir(ORIGINAL_DIR, { recursive: true });
+  await checkOrUpdateYaml(version);
 };
 
 collect();
-
-// const download = require("download");
-// const walk = require("walk-sync");
-// const { difference } = require("lodash");
-
-// const getVersions = require("./getVersions");
-// const { supportedVersions } = require("../package.json");
-
-// const contentDir = path.join(__dirname, "content");
-// const originalSourceLocale = "en-US";
-
-// collect();
-
-// async function collect() {
-//   const nodeVersions = await getVersions(supportedVersions);
-//   for (const major in nodeVersions) {
-//     const version = nodeVersions[major];
-//     await getDocsForNodeVersion(major, version).catch((err) => {
-//       console.error(`problem fetching version: ${version}`);
-//       console.error(err);
-//     });
-//   }
-// }
-
-// async function getDocsForNodeVersion(major, version) {
-//   const docDir = path.join(contentDir, major, originalSourceLocale);
-//   const downloadOptions = {
-//     extract: true,
-//     strip: 1,
-//     filter: (file) =>
-//       path.extname(file.path) === ".md" && file.path.startsWith("doc"),
-//   };
-
-//   // clean out english translations to ensure old files are removed
-//   fs.remove(docDir);
-
-//   // download repo bundle and extract
-//   const tarballUrl = `https://github.com/semver/semver/archive/${version}.tar.gz`;
-//   console.log("downloading", tarballUrl);
-//   await download(tarballUrl, docDir, downloadOptions);
-//   await cleanupTranslations(major);
-// }
-
-// const cleanupTranslations = async (version) => {
-//   const languages = fs.readdirSync(path.join(contentDir, version));
-//   const originalPath = path.join(
-//     contentDir,
-//     version,
-//     originalSourceLocale,
-//     "doc"
-//   );
-//   const originalFiles = walk(originalPath, { directories: false });
-//   await Promise.all(
-//     languages.map((language) => {
-//       const translatedPath = path.join(contentDir, version, language, "doc");
-//       const translatedFiles = walk(translatedPath, {
-//         directories: false,
-//       });
-//       const translatedOriginDiff = difference(translatedFiles, originalFiles);
-//       return Promise.all(
-//         translatedOriginDiff.map((filePath) => {
-//           const fileToRemovePath = path.join(translatedPath, filePath);
-//           console.log("Removed:", fileToRemovePath);
-//           return fs.remove(fileToRemovePath);
-//         })
-//       );
-//     })
-//   );
-// };

--- a/spec/v2.0.0.md
+++ b/spec/v2.0.0.md
@@ -1,9 +1,5 @@
----
-title: Semantic Versioning 2.0.0
----
-
 Semantic Versioning 2.0.0
-=========================
+==============================
 
 Summary
 -------
@@ -58,7 +54,7 @@ Semantic Versioning Specification (SemVer)
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
+interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
 1. Software using Semantic Versioning MUST declare a public API. This API
 could be declared in the code itself or exist strictly in documentation.
@@ -97,22 +93,22 @@ version is incremented.
 
 1. A pre-release version MAY be denoted by appending a hyphen and a
 series of dot separated identifiers immediately following the patch
-version. Identifiers MUST comprise only ASCII alphanumerics and hyphen
+version. Identifiers MUST comprise only ASCII alphanumerics and hyphens
 [0-9A-Za-z-]. Identifiers MUST NOT be empty. Numeric identifiers MUST
 NOT include leading zeroes. Pre-release versions have a lower
 precedence than the associated normal version. A pre-release version
 indicates that the version is unstable and might not satisfy the
 intended compatibility requirements as denoted by its associated
 normal version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7,
-1.0.0-x.7.z.92.
+1.0.0-x.7.z.92, 1.0.0-x-y-z.--.
 
 1. Build metadata MAY be denoted by appending a plus sign and a series of dot
 separated identifiers immediately following the patch or pre-release version.
-Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-].
+Identifiers MUST comprise only ASCII alphanumerics and hyphens [0-9A-Za-z-].
 Identifiers MUST NOT be empty. Build metadata MUST be ignored when determining
 version precedence. Thus two versions that differ only in the build metadata,
 have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700,
-1.0.0-beta+exp.sha.5114f85.
+1.0.0-beta+exp.sha.5114f85, 1.0.0+21AF26D3----117B344092BD.
 
 1. Precedence refers to how versions are compared to each other when ordered.
 Precedence MUST be calculated by separating the version into major, minor, patch
@@ -349,8 +345,8 @@ See: <https://regex101.com/r/vkijKf/1/>
 About
 -----
 
-The Semantic Versioning specification is authored by [Tom
-Preston-Werner](http://tom.preston-werner.com), inventor of Gravatar and
+The Semantic Versioning specification was originally authored by [Tom
+Preston-Werner](https://tom.preston-werner.com), inventor of Gravatar and
 cofounder of GitHub.
 
 If you'd like to leave feedback, please [open an issue on
@@ -360,4 +356,4 @@ GitHub](https://github.com/semver/semver/issues).
 License
 -------
 
-[Creative Commons - CC BY 3.0](http://creativecommons.org/licenses/by/3.0/)
+[Creative Commons - CC BY 3.0](https://creativecommons.org/licenses/by/3.0/)


### PR DESCRIPTION
Hey folks
Here is GitHub Actions solution to check for updates from original repository [semver/semver](https://github.com/semver/semver) and create PR with updates (if exist). I did the same thing for [Node.js](https://github.com/nodejs/i18n/blob/master/.github/workflows/nightly-sync.yml), so it's tested well.

## How it works?

- Every day at 3AM UTC cronjob run GitHub Action workflow _.github/workflows/sync.yml_
- This workflow bootstrap node environment and run npm-script
- npm-script call JavaScript file _scripts/collect.js_
- inside file:
  - clonning original repo
  - parsing version from _semver.md_
  - copy with overwrite this file to website repository _spec/${PARSED VERSION}.md_
  - update _\_config.yml_ with new version (if exist)
- workflow run [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request), which create PR with updates (if exist)

That's basically it :smiley:

## Why it is?

Because we need to keep website version and original spec version up-to-date and there are two ways:
- manual (current)
- automated (proposed)

Let's delegate this task to machines
![image](https://lh3.googleusercontent.com/proxy/HvC8Yq1qB04NBrZic6N5J_Z_gU_1a37EztEWlNuAPsmh2IFu-rnb6QozmrqB3F_7BBb8NBu41WyOUoXQq3C7g-gsDitNcu-ueAiU814IFDlBOPPc_7r3sRh01Y_uX5WlW8UzHqPKXn8XPlFlPEL5G-qa)


Any feedback or objections are welcome :+1: 

/cc @indirect @haacked @isaacs @mojombo @segiddins Please review