### PR TITLE
fix/anchors

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
     {% seo %}
   </head>
   <body>
-    <ol class="nav lang" dir="ltr">
+    <ul class="nav lang" dir="ltr">
       {% assign sorted_languages = site.languages | sort %}
       {% for language in sorted_languages %}
         <li class="language language-{{ language[0] }}">
@@ -19,8 +19,8 @@
             >{{ language[1] | smartify }} ({{ language[0] }})</a>
         </li>
       {% endfor %}
-    </ol>
-    <ol class="nav">
+    </ul>
+    <ul class="nav">
       {% assign language = page.language | default: "en" %}
       {% for version in site.versions %}
         {% if language == "en" %}
@@ -35,7 +35,7 @@
           </li>
         {% endif %}
       {% endfor %}
-    </ol>
+    </ul>
     <div id="spec">
      {{ content }}
     </div>

--- a/css/main.css
+++ b/css/main.css
@@ -4,7 +4,7 @@ CSS for semver.org
 @link http://mathiasbynens.be/
 */
 
-h1, h2, ol { margin: 0; padding: 0; }
+h1, h2, ol, ul { margin: 0; padding: 0; }
 
 html { font: 14.4px/1.5 Helvetica, Arial, sans-serif; }
 body { margin: 0 auto; padding: 0 10%; max-width: 710px; color: #000; background-color: #fff; }
@@ -27,8 +27,8 @@ h1, h2, h3 {
 
 a { color: #009; }
 a:hover, a:focus { color: #000; }
-ol { padding-left: 1.5em; }
-html[dir="rtl"] ol {
+ol, ul { padding-left: 1.5em; }
+html[dir="rtl"] ol, html[dir="rtl"] ul {
     padding-left: 0;
     padding-right: 1.5em;
 }
@@ -43,7 +43,7 @@ p { margin: 0 0 1em; }
 
 /* Nav */
 
-ol.nav {
+ul.nav {
   background-color: #333;
   list-style-type: none;
   margin: 0;
@@ -51,25 +51,25 @@ ol.nav {
   overflow: hidden;
 }
 
-ol.nav li {
+ul.nav li {
   display: inline;
   font-weight: bold;
   margin: 0 0.5em;
   white-space: nowrap;
 }
 
-ol.nav li a {
+ul.nav li a {
   color: white;
 }
 
-ol.lang {
+ul.lang {
   background-color: white;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
 }
 
-ol.lang li a {
+ul.lang li a {
   color: black;
 }
 

--- a/js/anchorli.js
+++ b/js/anchorli.js
@@ -1,29 +1,27 @@
-document.onreadystatechange = function () {
-  if (this.readyState === "complete") {
+const createAnchorLink = (id) => {
+  const anchor = document.createElement("a");
+  anchor.className = "anchor-link";
+  anchor.href = "#" + id;
+  return anchor;
+};
 
-    var createAnchorLink = function (id) {
-      var anchor = document.createElement("a");
-      anchor.className = "anchor-link";
-      anchor.href      = "#" + id;
-      return anchor;
-    };
-
-    // Add IDs to all spec li elements
-    var specItems = document.querySelectorAll("#spec ol")[1]
-      .querySelectorAll('li');
-    for (var i = 0; i < specItems.length; i++)
-    {
-      var li = specItems[i];
-      li.id = 'spec-item-' + (i + 1);
+window.onload = () => {
+  let increment = 0;
+  [...document.querySelectorAll("h1, h2, h3, #spec li > p")].forEach((el) => {
+    if (el.id) {
+      const anchorLink = createAnchorLink(el.id);
+      el.insertBefore(anchorLink, el.firstChild);
+    } else {
+      increment++;
+      el.parentElement.id = "spec-item-" + increment;
+      const anchorLink = createAnchorLink(el.parentElement.id);
+      el.parentElement.insertBefore(anchorLink, el);
     }
+  });
 
-    // Add anchor link to all elemens with an ID in the spec
-    var headers = document.querySelectorAll('#spec [id]');
-    for (var i = 0; i < headers.length; i++)
-    {
-      var element = headers[i];
-      var anchorLink = createAnchorLink(element.id);
-      element.insertBefore(anchorLink, element.firstChild)
-    }
+  const hash = window.location.hash;
+  if (hash) {
+    const targetElTop = document.querySelector(hash).offsetTop;
+    window.scrollTo(0, targetElTop);
   }
 };


### PR DESCRIPTION
Fix for #263 
Problem described in the issue related to dynamically generated ids for elements. When browser loads page with hash in url it tries to scrollTo element with matched id/name, and it works for headers, beacuse ids for them exist by default. Ids for `li` generating dynamically, and browser don't scroll automatically. Something like:

```sh
# header predefined id
load page -> check hash -> find matched element -> scrollTo

# li with dynamically generated id
load page -> check hash -> find matched element -> fail -> onload event -> generate id
```

![image](https://user-images.githubusercontent.com/28801003/84601592-fc028e80-ae89-11ea-877a-32d512f4afd5.png)

I tried to find how to make the same predefined ids for list elements, but nothing elegant. For example, we can add meta to each element and additional parser to apply it:

```md
1. {:#spec-item-1} Software using Semantic Versioning MUST declare a public API. This API
could be declared in the code itself or exist strictly in documentation.
However it is done, it SHOULD be precise and comprehensive.

1. {:#spec-item-2} A normal version number MUST take the form X.Y.Z where X, Y, and Z are
non-negative integers, and MUST NOT contain leading zeroes. X is the
major version, Y is the minor version, and Z is the patch version.
Each element MUST increase numerically. For instance: 1.9.0 -> 1.10.0 -> 1.11.0.
```

But it should be added everywhere around the project and looks ugly :confused:, so I decided to just add a bit more JS code to page.

## What's done?

1. Replaced `<ol>` with `<ul>` by semantic reasons
2. Refactored _anchorli.js_ with ES6 syntax https://github.com/semver/semver.org/compare/gh-pages...alexandrtovmach:fix/anchor-scroll?expand=1#diff-20c4c3be4ab0a92436902027898c9839L1-L19
3. Added functionality to force scroll to element by hash (actual fix) https://github.com/semver/semver.org/compare/gh-pages...alexandrtovmach:fix/anchor-scroll?expand=1#diff-20c4c3be4ab0a92436902027898c9839R22-R26