### PR TITLE
Fix English navigation link to home

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,11 @@
       {% for language in sorted_languages %}
         <li class="language language-{{ language[0] }}">
           <a rel="alternate" lang="{{ language[0] }}" hreflang="{{ language[0] }}"
-            href="{{ language[0] | prepend: "/lang/" }}"
+            {% if language[0] == "en" %}
+              href="/"
+            {% else %}
+              href="{{ language[0] | prepend: "/lang/" }}"
+            {% endif %}
             >{{ language[1] | smartify }} ({{ language[0] }})</a>
         </li>
       {% endfor %}


### PR DESCRIPTION
The English version link in the navigation points to https://semver.org/lang/en which does not exist.
 