### PR TITLE
Update polish translation

### DIFF
--- a/lang/pl/index.md
+++ b/lang/pl/index.md
@@ -90,7 +90,7 @@ w [RFC 2119](http://tools.ietf.org/html/rfc2119).
 7. Wersja minor Y (x.Y.z | x > 0) MUSI zostać zwiększona, jeśli nowa,
    kompatybilna wstecz funkcjonalność zostaje wprowadzona do publicznego API. MUSI
    zostać zwiększona, jeśli jakakolwiek funkcjonalność publicznego API zostaje
-   wycofane. MOŻE zostać zwiększona, jeśli wprowadzone zostają nowe znaczące
+   zdezaprobowana. MOŻE zostać zwiększona, jeśli wprowadzone zostają nowe znaczące
    funkcjonalności lub ulepszenia w obrębie prywatnego kodu. MOŻE ona zawierać
    zmiany na poziomie patch. Numer wersji patch MUSI być ustawiony na 0, gdy wersja
    minor jest zwiększana.
@@ -310,15 +310,15 @@ w semantycznym wersjonowaniu chodzi przede wszystkim o przekazanie znaczenia
 zmiany poprzez zmianę numeru wersji. Jeśli zmiany są ważne dla użytkowników,
 poinformuj ich o tym poprzez numer wersji.
 
-### Jak powinienem radzić sobie z wycofywaniem funkcjonalności?
+### Jak powinienem radzić sobie z dezaprobowaniem funkcjonalności?
 
-Wycofywanie istniejącej funkcjonalności jest normalną częścią programowania
+Dezaprobowanie istniejącej funkcjonalności jest normalną częścią programowania
 i często jest konieczne, by móc rozwijać oprogramowanie. Gdy wycofujesz część
 swojego publicznego API, powinieneś zrobić dwie rzeczy: (1) zaktualizować
 dokumentację, by użytkownicy wiedzieli o tej zmianie, (2) wypuścić nowe wydanie
-minor z informacją o wycofywaniu. Zanim całkowicie usuniesz funkcjonalność
+minor z informacją o zdezaprobowaniu. Zanim całkowicie usuniesz funkcjonalność
 w nowym wydaniu major, powinno być co najmniej jedno wydanie minor zawierające
-informację o wycofaniu, aby użytkownicy mogli płynnie przejść na nowe API.
+informację o zdezaprobowanie, aby użytkownicy mogli płynnie przejść na nowe API.
 
 ### Czy SemVer ma limit długości na oznaczenie wersji?
 

--- a/lang/pl/index.md
+++ b/lang/pl/index.md
@@ -316,7 +316,7 @@ Wycofywanie istniejącej funkcjonalności jest normalną częścią programowani
 i często jest konieczne, by móc rozwijać oprogramowanie. Gdy wycofujesz część
 swojego publicznego API, powinieneś zrobić dwie rzeczy: (1) zaktualizować
 dokumentację, by użytkownicy wiedzieli o tej zmianie, (2) wypuścić nowe wydanie
-minor z informacją o wycofaniu. Zanim całkowicie usuniesz funkcjonalność
+minor z informacją o wycofywaniu. Zanim całkowicie usuniesz funkcjonalność
 w nowym wydaniu major, powinno być co najmniej jedno wydanie minor zawierające
 informację o wycofaniu, aby użytkownicy mogli płynnie przejść na nowe API.
 

--- a/lang/pl/index.md
+++ b/lang/pl/index.md
@@ -64,80 +64,146 @@ i „OPCJONALNY” („OPTIONAL”) w tym dokumencie należy interpretować jak 
 w [RFC 2119](http://tools.ietf.org/html/rfc2119).
 
 1. Oprogramowanie używające wersjonowania semantycznego MUSI określać swoje
-publiczne API. API to może być zadeklarowane w samym kodzie lub może istnieć
-w samej dokumentacji. Jakkolwiek jest zdefiniowane, powinno być precyzyjne
-i wyczerpujące.
+   publiczne API. API to może być zadeklarowane w samym kodzie lub może istnieć
+   w samej dokumentacji. Jakkolwiek jest zdefiniowane, powinno być precyzyjne
+   i wyczerpujące.
 
 2. Standardowy numer wersji MUSI przyjąć formę X.Y.Z, gdzie X, Y i Z są
-nieujemnymi liczbami całkowitymi i NIE MOGĄ zawierać wiodących zer. X jest
-wersją major, Y wersją minor, a Z wersją patch. Każdy składnik MUSI rosnąć
-numerycznie. Przykładowo: 1.9.0 → 1.10.0 → 1.11.0.
+   nieujemnymi liczbami całkowitymi i NIE MOGĄ zawierać wiodących zer. X jest
+   wersją major, Y wersją minor, a Z wersją patch. Każdy składnik MUSI rosnąć
+   numerycznie. Przykładowo: 1.9.0 → 1.10.0 → 1.11.0.
 
-3. Po wydaniu wersjonowanego pakietu, zawartość tej wersji NIE MOŻE być
-modyfikowana. Jakiekolwiek zmiany MUSZĄ być wydane jako nowa wersja.
+3. Po wydaniu wersjonowanego pakietu zawartość tej wersji NIE MOŻE być
+   modyfikowana. Jakiekolwiek zmiany MUSZĄ być wydane jako nowa wersja.
 
 4. Wersja major zero (0.y.z) jest przeznaczona dla początkowej fazy rozwoju.
-Wszystko może ulec zmianie w dowolnym momencie. Publiczne API nie powinno być
-traktowane jako stabilne.
+   Wszystko może ulec zmianie w dowolnym momencie. Publiczne API nie powinno być
+   traktowane jako stabilne.
 
 5. Wersja 1.0.0 określa publiczne API. Sposób, w jaki numer wersji jest
-zwiększany po tym wydaniu, zależy od tego publicznego API i jak się ono zmienia.
+   zwiększany po tym wydaniu, zależy od tego publicznego API i jak się ono zmienia.
 
 6. Wersja patch Z (x.y.Z | x > 0) MUSI zostać zwiększona, jeśli wprowadza się
-tylko kompatybilne wstecz naprawy błędów. Naprawa błędu definiowana jest jako
-zmiana wewnętrzna, która usuwa nieprawidłowe działanie.
+   tylko kompatybilne wstecz naprawy błędów. Naprawa błędu definiowana jest jako
+   zmiana wewnętrzna, która usuwa nieprawidłowe działanie.
 
 7. Wersja minor Y (x.Y.z | x > 0) MUSI zostać zwiększona, jeśli nowa,
-kompatybilna wstecz funkcjonalność zostaje wprowadzona do publicznego API. MUSI
-zostać zwiększona, jeśli jakakolwiek funkcjonalność publicznego API zostaje
-zdezaprobowana. MOŻE zostać zwiększona, jeśli wprowadzone zostają nowe znaczące
-funkcjonalności lub ulepszenia w obrębie prywatnego kodu. MOŻE ona zawierać
-zmiany na poziomie patch. Numer wersji patch MUSI być ustawiony na 0, gdy wersja
-minor jest zwiększana.
+   kompatybilna wstecz funkcjonalność zostaje wprowadzona do publicznego API. MUSI
+   zostać zwiększona, jeśli jakakolwiek funkcjonalność publicznego API zostaje
+   wycofane. MOŻE zostać zwiększona, jeśli wprowadzone zostają nowe znaczące
+   funkcjonalności lub ulepszenia w obrębie prywatnego kodu. MOŻE ona zawierać
+   zmiany na poziomie patch. Numer wersji patch MUSI być ustawiony na 0, gdy wersja
+   minor jest zwiększana.
 
 8. Wersja major X (X.y.z | X > 0) MUSI zostać zwiększona, jeżeli do publicznego
-API są wprowadzane jakiekolwiek wstecznie niekompatybilne zmiany. MOŻE zawierać
-zmiany na poziomie minor oraz patch. Numery wersji minor oraz patch MUSZĄ być
-ustawione na 0, gdy wersja major jest zwiększana.
+   API są wprowadzane jakiekolwiek wstecznie niekompatybilne zmiany. MOŻE zawierać
+   zmiany na poziomie minor oraz patch. Numery wersji minor oraz patch MUSZĄ być
+   ustawione na 0, gdy wersja major jest zwiększana.
 
 9. Wydanie przedpremierowe MOŻE być oznaczone przez dołączenie dywizu oraz
-zbioru identyfikatorów rozdzielonych kropkami, zaraz za numerem wersji
-patch. Identyfikatory MUSZĄ składać się wyłącznie ze znaków alfanumerycznych
-ASCII oraz myślników [0-9A-Za-z-]. Identyfikatory NIE MOGĄ być puste. Numeryczne
-identyfikatory NIE MOGĄ zawierać wiodących zer. Wydania przedpremierowe
-poprzedzają powiązane z nimi wersje standardowe. Wydanie przedpremierowe
-wskazuje na niestabilność wersji i możliwość niespełniania wymogów
-kompatybilności, które cechują powiązaną z nią standardową wersję. Przykłady:
-1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92.
+   zbioru identyfikatorów rozdzielonych kropkami, zaraz za numerem wersji
+   patch. Identyfikatory MUSZĄ składać się wyłącznie ze znaków alfanumerycznych
+   ASCII oraz myślników [0-9A-Za-z-]. Identyfikatory NIE MOGĄ być puste. Numeryczne
+   identyfikatory NIE MOGĄ zawierać wiodących zer. Wydania przedpremierowe
+   poprzedzają powiązane z nimi wersje standardowe. Wydanie przedpremierowe
+   wskazuje na niestabilność wersji i możliwość niespełniania wymogów
+   kompatybilności, które cechują powiązaną z nią standardową wersję. Przykłady:
+   1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92.
 
 10. Meta-dane buildu MOGĄ być oznaczone przez dołączenie znaku plus oraz zbioru
-identyfikatorów rozdzielonych kropkami, zaraz za numerem wersji patch lub
-wydania przedpremierowego. Identyfikatory MUSZĄ składać się wyłącznie ze znaków
-alfanumerycznych ASCII oraz myślników [0-9A-Za-z-]. Identyfikatory NIE MOGĄ być
-puste. Meta-dane buildu POWINNY być ignorowane przy ustalaniu kolejności wersji.
-Zatem, dwie wersje różniące się tylko meta-danymi buildu mają ten sam stopień
-pierwszeństwa. Przykłady: 1.0.0-alpha+001, 1.0.0+20130313144700,
-1.0.0-beta+exp.sha.5114f85.
+    identyfikatorów rozdzielonych kropkami, zaraz za numerem wersji patch lub
+    wydania przedpremierowego. Identyfikatory MUSZĄ składać się wyłącznie ze znaków
+    alfanumerycznych ASCII oraz myślników [0-9A-Za-z-]. Identyfikatory NIE MOGĄ być
+    puste. Meta-dane buildu POWINNY być ignorowane przy ustalaniu kolejności wersji.
+    Zatem dwie wersje różniące się tylko meta-danymi buildu mają ten sam stopień
+    pierwszeństwa. Przykłady: 1.0.0-alpha+001, 1.0.0+20130313144700,
+    1.0.0-beta+exp.sha.5114f85.
 
 11. Pierwszeństwo odnosi się do sposobu porównywania wersji między sobą podczas
-ich porządkowania. Pierwszeństwo MUSI być ustalane w rozdzieleniu wersji na
-identyfikatory major, minor, patch oraz identyfikator przedpremierowy w podanej
-kolejności (meta-dane buildu nie decydują o pierwszeństwie). Pierwszeństwo jest
-ustalane przez pierwszą różnicę wykrytą podczas porównania każdego
-z identyfikatorów od lewej do prawej: wersje major, minor, patch są zawsze
-porównywane numerycznie. Przykład: 1.0.0 < 2.0.0 < 2.1.0 < 2.1.1. Gdy numery
-wersji major, minor i patch są równe, wydanie przedpremierowe poprzedza wersję
-standardową. Przykładowo: 1.0.0-alpha < 1.0.0. Pierwszeństwo dwóch wydań
-przedpremierowych z takimi samymi numerami wersji major, minor i patch MUSI być
-ustalane przez porównywanie każdego z identyfikatorów rozdzielonych kropkami
-w kierunku od lewej do prawej, póki nie zostanie wykryta różnica w taki sposób:
-identyfikatory złożone z samych cyfr porównywane są numerycznie,
-a identyfikatory z literami lub dywizami porównywane są leksykalnie w kolejności
-ASCII. Identyfikatory numeryczne zawsze poprzedzają identyfikatory
-nienumeryczne. Większy zbiór przedpremierowych pól poprzedza mniejszy zbiór,
-o ile wszystkie poprzedzające identyfikatory są sobie równe. Przykład:
-1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 <
-1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
+    ich porządkowania. Pierwszeństwo MUSI być ustalane w rozdzieleniu wersji na
+    identyfikatory major, minor, patch oraz identyfikator przedpremierowy w podanej
+    kolejności (meta-dane buildu nie decydują o pierwszeństwie). Pierwszeństwo jest
+    ustalane przez pierwszą różnicę wykrytą podczas porównania każdego
+    z identyfikatorów od lewej do prawej: wersje major, minor, patch są zawsze
+    porównywane numerycznie. Przykład: 1.0.0 < 2.0.0 < 2.1.0 < 2.1.1. Gdy numery
+    wersji major, minor i patch są równe, wydanie przedpremierowe poprzedza wersję
+    standardową. Przykładowo: 1.0.0-alpha < 1.0.0. Pierwszeństwo dwóch wydań
+    przedpremierowych z takimi samymi numerami wersji major, minor i patch MUSI być
+    ustalane przez porównywanie każdego z identyfikatorów rozdzielonych kropkami
+    w kierunku od lewej do prawej, póki nie zostanie wykryta różnica w taki sposób:
+    identyfikatory złożone z samych cyfr porównywane są numerycznie,
+    a identyfikatory z literami lub dywizami porównywane są leksykalnie w kolejności
+    ASCII. Identyfikatory numeryczne zawsze poprzedzają identyfikatory
+    nienumeryczne. Większy zbiór przedpremierowych pól poprzedza mniejszy zbiór,
+    o ile wszystkie poprzedzające identyfikatory są sobie równe. Przykład:
+    1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 <
+    1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
+
+Gramatyka poprawnej wersji SemVer w zapisie BNF
+--------------------------------------------------
+```
+<valid semver> ::= <version core>
+                 | <version core> "-" <pre-release>
+                 | <version core> "+" <build>
+                 | <version core> "-" <pre-release> "+" <build>
+
+<version core> ::= <major> "." <minor> "." <patch>
+
+<major> ::= <numeric identifier>
+
+<minor> ::= <numeric identifier>
+
+<patch> ::= <numeric identifier>
+
+<pre-release> ::= <dot-separated pre-release identifiers>
+
+<dot-separated pre-release identifiers> ::= <pre-release identifier>
+                                          | <pre-release identifier> "." <dot-separated pre-release identifiers>
+
+<build> ::= <dot-separated build identifiers>
+
+<dot-separated build identifiers> ::= <build identifier>
+                                    | <build identifier> "." <dot-separated build identifiers>
+
+<pre-release identifier> ::= <alphanumeric identifier>
+                           | <numeric identifier>
+
+<build identifier> ::= <alphanumeric identifier>
+                     | <digits>
+
+<alphanumeric identifier> ::= <non-digit>
+                            | <non-digit> <identifier characters>
+                            | <identifier characters> <non-digit>
+                            | <identifier characters> <non-digit> <identifier characters>
+
+<numeric identifier> ::= "0"
+                       | <positive digit>
+                       | <positive digit> <digits>
+
+<identifier characters> ::= <identifier character>
+                          | <identifier character> <identifier characters>
+
+<identifier character> ::= <digit>
+                         | <non-digit>
+
+<non-digit> ::= <letter>
+              | "-"
+
+<digits> ::= <digit>
+           | <digit> <digits>
+
+<digit> ::= "0"
+          | <positive digit>
+
+<positive digit> ::= "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+
+<letter> ::= "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J"
+           | "K" | "L" | "M" | "N" | "O" | "P" | "Q" | "R" | "S" | "T"
+           | "U" | "V" | "W" | "X" | "Y" | "Z" | "a" | "b" | "c" | "d"
+           | "e" | "f" | "g" | "h" | "i" | "j" | "k" | "l" | "m" | "n"
+           | "o" | "p" | "q" | "r" | "s" | "t" | "u" | "v" | "w" | "x"
+           | "y" | "z"
+```
 
 Dlaczego warto stosować wersjonowanie semantyczne?
 --------------------------------------------------
@@ -158,12 +224,12 @@ zamienić piekło zależności w relikt przeszłości. Rozważmy bibliotekę naz
 3.1.0. Jako że Wóz strażacki korzysta z funkcjonalności, które zostały
 wprowadzone po raz pierwszy w wersji 3.1.0, możesz bezpiecznie założyć, że
 wymagana wersja Drabiny jest większa lub równa 3.1.0, ale mniejsza niż 4.0.0.
-Teraz, gdy staną się dostępne wersje Drabiny 3.1.1 lub 3.2.0, możesz puścić je
+Teraz gdy staną się dostępne wersje Drabiny 3.1.1 lub 3.2.0, możesz puścić je
 w swoim systemie zarządzania pakietami ze świadomością, że będą one kompatybilne
 z istniejącym zależnym oprogramowaniem.
 
 Jako odpowiedzialny programista musisz oczywiście zweryfikować, że każde
-aktualizacje pakietów działają jak powinny. Prawdziwy świat potrafi dać w kość;
+aktualizacje pakietów działają, jak powinny. Prawdziwy świat potrafi dać w kość;
 nic nie możemy z tym zrobić poza zachowaniem czujności. To, co ty możesz zrobić,
 to pozwolić by wersjonowanie semantyczne dostarczyło ci rozsądną metodę
 wydawania i aktualizowania pakietów bez konieczności wydawania nowych
@@ -201,7 +267,7 @@ To jest kwestia odpowiedzialnego programowania i dalekowzroczności.
 Niekompatybilne zmiany nie powinny być wprowadzane z lekkością do
 oprogramowania, które jest zależnością w wielu miejscach. Koszt, który trzeba
 ponieść, by zaktualizować pakiet, może być znamienny. Konieczność podbijania
-wersji major przy wprowadzaniu niekompatybilnych zmian powoduje, że będziesz
+wersji major przy wprowadzaniu niekompatybilnych zmian powoduje, że będziesz
 myślał przez pryzmat siły oddziaływania swoich zmian i szacował stosunek
 poniesionych kosztów do zysków.
 
@@ -210,7 +276,7 @@ poniesionych kosztów do zysków.
 Jako profesjonalny programista jesteś odpowiedzialny za prawidłową dokumentację
 oprogramowania, które jest przeznaczone do użytku przez innych. Zarządzanie
 złożonością oprogramowania jest niezwykle ważną częścią utrzymania sprawności
-projektu, a jest to trudne do zrobienia, jeśli nikt nie wie jak używać twojego
+projektu, a jest to trudne do zrobienia, jeśli nikt nie wie, jak używać twojego
 oprogramowania albo z których metod jest bezpiecznie korzystać. Na dłuższą metę
 wersjonowanie semantyczne oraz obstawanie przy dobrze zdefiniowanym publicznym
 API pozwoli wszystkim i wszystkiemu działać płynnie.
@@ -223,18 +289,18 @@ wsteczną kompatybilność. Nawet w takich okolicznościach niedopuszczalne jest
 modyfikowanie wydanej wersji. Jeśli możesz, opisz błędną wersję i poinformuj
 użytkowników o problemie, aby byli świadomi, że ta wersja jest błędna.
 
-### Co powinienem zrobić jeśli aktualizuję własne zależności bez zmiany publicznego API?
+### Co powinienem zrobić, jeśli aktualizuję własne zależności bez zmiany publicznego API?
 
 Taka aktualizacja jest uznawana za kompatybilną, gdyż nie narusza publicznego
 API. Oprogramowanie, które opiera się na tych samych zależnościach co twój
 pakiet, powinno mieć własną specyfikację zależności, a jego autor zauważy
-konflikt. Ustalenie, czy zmiana jest na poziomie patch lub czy jest modyfikacją
-na poziomie minor zależy od tego, czy zaktualizowałeś zależności w celu naprawy
+konflikt. Ustalenie, czy zmiana jest na poziomie patch lub, czy jest modyfikacją
+na poziomie minor, zależy od tego, czy zaktualizowałeś zależności w celu naprawy
 błędu, czy w celu wprowadzenia nowej funkcjonalności. Zazwyczaj spodziewałbym
 się dodatkowego kodu w tym drugim przypadku, co oczywiście oznacza zwiększenie
 wersji minor.
 
-### Co jeśli nieumyślnie zmieniłem publiczne API w taki sposób, że nie jest już zgodne ze zmianą numeru wersji (tj. kod nieprawidłowo wprowadza zmianę major w wydaniu patch)?
+### Co zrobić, gdy nieumyślnie zmieniłem publiczne API w taki sposób, że nie jest już zgodne ze zmianą numeru wersji (tj. kod nieprawidłowo wprowadza zmianę major w wydaniu patch)?
 
 Postępuj zgodnie z rozsądkiem. Jeśli oprogramowanie używane jest przez wielu
 użytkowników, dla których zmiana publicznego API do poprzednio zamierzonego
@@ -244,21 +310,48 @@ w semantycznym wersjonowaniu chodzi przede wszystkim o przekazanie znaczenia
 zmiany poprzez zmianę numeru wersji. Jeśli zmiany są ważne dla użytkowników,
 poinformuj ich o tym poprzez numer wersji.
 
-### Jak powinienem radzić sobie z dezaprobowaniem funkcjonalności?
+### Jak powinienem radzić sobie z wycofywaniem funkcjonalności?
 
-Dezaprobowanie istniejącej funkcjonalności jest normalną częścią programowania
+Wycofywanie istniejącej funkcjonalności jest normalną częścią programowania
 i często jest konieczne, by móc rozwijać oprogramowanie. Gdy wycofujesz część
 swojego publicznego API, powinieneś zrobić dwie rzeczy: (1) zaktualizować
 dokumentację, by użytkownicy wiedzieli o tej zmianie, (2) wypuścić nowe wydanie
-minor z informacją o zdezaprobowaniu. Zanim całkowicie usuniesz funkcjonalność
+minor z informacją o wycofaniu. Zanim całkowicie usuniesz funkcjonalność
 w nowym wydaniu major, powinno być co najmniej jedno wydanie minor zawierające
-zdezaprobowanie, aby użytkownicy mogli płynnie przejść na nowe API.
+informację o wycofaniu, aby użytkownicy mogli płynnie przejść na nowe API.
 
-### Czy semver ma limit długości na oznaczenie wersji?
+### Czy SemVer ma limit długości na oznaczenie wersji?
 
 Nie, ale miej zdrowy rozsądek. Na przykład numer wersji długi na 255 znaków to
 prawdopodobnie przesada. Ponadto konkretne systemy mogą narzucać swoje własne
 ograniczenia na rozmiar tego ciągu znaków.
+
+### Czy ciąg „v1.2.3” spełnia zasady?
+
+Nie, „v1.2.3” nie jest zgodne z wersjonowaniem semantycznym. Jednak przedrostek „v” jest
+zazwyczaj używany w języku angielskim do oznaczenia, że mamy do czynienia z numerem wersji.
+Skrót „v” od angielskiego słowa „version” jest często spotykany w systemach kontroli wersji.
+Przykładowo, w przypadku `git tag v1.2.3 -m "Release version 1.2.3"`, „v1.2.3” jest nazwą taga,
+a semantyczna wersja to „1.2.3”.
+
+### Czy istnieje sugerowane wyrażenie regularne (RegEx) do weryfikacji porawności SemVer?
+
+Istnieją dwa. Pierwsze wykorzystuje grupy nazwane i jest przeznaczone dla systemów, które
+wspierają tę funkcjonalność (PCRE [Perl Compatible Regular Expressions, np. Perl, PHP i R], Python czy Go).
+
+Patrz: https://regex101.com/r/Ly7O1x/3/
+```
+^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+```
+
+Druga wykorzystuje numerowane grupy przechwytujące (wzór gp1 = major, gp2 = minor, gp3 = patch, gp4 = przedpremierowa i gp5 = meta-dane buildu)
+i jest kompatybilna z ECMA Script (JavaScript), PCRE [Perl Compatible Regular Expressions, np. Perl, PHP i R], Python czy Go.
+
+Patrz: https://regex101.com/r/vkijKf/1/
+
+```
+^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+```
 
 O specyfikacji
 --------------

--- a/lang/pl/index.md
+++ b/lang/pl/index.md
@@ -318,7 +318,7 @@ swojego publicznego API, powinieneś zrobić dwie rzeczy: (1) zaktualizować
 dokumentację, by użytkownicy wiedzieli o tej zmianie, (2) wypuścić nowe wydanie
 minor z informacją o zdezaprobowaniu. Zanim całkowicie usuniesz funkcjonalność
 w nowym wydaniu major, powinno być co najmniej jedno wydanie minor zawierające
-informację o zdezaprobowanie, aby użytkownicy mogli płynnie przejść na nowe API.
+informację o zdezaprobowaniu, aby użytkownicy mogli płynnie przejść na nowe API.
 
 ### Czy SemVer ma limit długości na oznaczenie wersji?
 
@@ -344,8 +344,9 @@ Patrz: https://regex101.com/r/Ly7O1x/3/
 ^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
 ```
 
-Druga wykorzystuje numerowane grupy przechwytujące (wzór gp1 = major, gp2 = minor, gp3 = patch, gp4 = przedpremierowa i gp5 = meta-dane buildu)
-i jest kompatybilna z ECMA Script (JavaScript), PCRE [Perl Compatible Regular Expressions, np. Perl, PHP i R], Python czy Go.
+Druga wykorzystuje numerowane grupy przechwytujące (wzór gp1 = major, gp2 = minor, gp3 = patch, gp4 = przedpremierowa i gp5 =
+meta-dane buildu) i jest kompatybilna z ECMA Script (JavaScript), PCRE [Perl Compatible Regular Expressions, np. Perl, PHP i R],
+Python czy Go.
 
 Patrz: https://regex101.com/r/vkijKf/1/
 

--- a/lang/pl/spec/v2.0.0.md
+++ b/lang/pl/spec/v2.0.0.md
@@ -64,80 +64,146 @@ i „OPCJONALNY” („OPTIONAL”) w tym dokumencie należy interpretować jak 
 w [RFC 2119](http://tools.ietf.org/html/rfc2119).
 
 1. Oprogramowanie używające wersjonowania semantycznego MUSI określać swoje
-publiczne API. API to może być zadeklarowane w samym kodzie lub może istnieć
-w samej dokumentacji. Jakkolwiek jest zdefiniowane, powinno być precyzyjne
-i wyczerpujące.
+   publiczne API. API to może być zadeklarowane w samym kodzie lub może istnieć
+   w samej dokumentacji. Jakkolwiek jest zdefiniowane, powinno być precyzyjne
+   i wyczerpujące.
 
 2. Standardowy numer wersji MUSI przyjąć formę X.Y.Z, gdzie X, Y i Z są
-nieujemnymi liczbami całkowitymi i NIE MOGĄ zawierać wiodących zer. X jest
-wersją major, Y wersją minor, a Z wersją patch. Każdy składnik MUSI rosnąć
-numerycznie. Przykładowo: 1.9.0 → 1.10.0 → 1.11.0.
+   nieujemnymi liczbami całkowitymi i NIE MOGĄ zawierać wiodących zer. X jest
+   wersją major, Y wersją minor, a Z wersją patch. Każdy składnik MUSI rosnąć
+   numerycznie. Przykładowo: 1.9.0 → 1.10.0 → 1.11.0.
 
-3. Po wydaniu wersjonowanego pakietu, zawartość tej wersji NIE MOŻE być
-modyfikowana. Jakiekolwiek zmiany MUSZĄ być wydane jako nowa wersja.
+3. Po wydaniu wersjonowanego pakietu zawartość tej wersji NIE MOŻE być
+   modyfikowana. Jakiekolwiek zmiany MUSZĄ być wydane jako nowa wersja.
 
 4. Wersja major zero (0.y.z) jest przeznaczona dla początkowej fazy rozwoju.
-Wszystko może ulec zmianie w dowolnym momencie. Publiczne API nie powinno być
-traktowane jako stabilne.
+   Wszystko może ulec zmianie w dowolnym momencie. Publiczne API nie powinno być
+   traktowane jako stabilne.
 
 5. Wersja 1.0.0 określa publiczne API. Sposób, w jaki numer wersji jest
-zwiększany po tym wydaniu, zależy od tego publicznego API i jak się ono zmienia.
+   zwiększany po tym wydaniu, zależy od tego publicznego API i jak się ono zmienia.
 
 6. Wersja patch Z (x.y.Z | x > 0) MUSI zostać zwiększona, jeśli wprowadza się
-tylko kompatybilne wstecz naprawy błędów. Naprawa błędu definiowana jest jako
-zmiana wewnętrzna, która usuwa nieprawidłowe działanie.
+   tylko kompatybilne wstecz naprawy błędów. Naprawa błędu definiowana jest jako
+   zmiana wewnętrzna, która usuwa nieprawidłowe działanie.
 
 7. Wersja minor Y (x.Y.z | x > 0) MUSI zostać zwiększona, jeśli nowa,
-kompatybilna wstecz funkcjonalność zostaje wprowadzona do publicznego API. MUSI
-zostać zwiększona, jeśli jakakolwiek funkcjonalność publicznego API zostaje
-zdezaprobowana. MOŻE zostać zwiększona, jeśli wprowadzone zostają nowe znaczące
-funkcjonalności lub ulepszenia w obrębie prywatnego kodu. MOŻE ona zawierać
-zmiany na poziomie patch. Numer wersji patch MUSI być ustawiony na 0, gdy wersja
-minor jest zwiększana.
+   kompatybilna wstecz funkcjonalność zostaje wprowadzona do publicznego API. MUSI
+   zostać zwiększona, jeśli jakakolwiek funkcjonalność publicznego API zostaje
+   wycofane. MOŻE zostać zwiększona, jeśli wprowadzone zostają nowe znaczące
+   funkcjonalności lub ulepszenia w obrębie prywatnego kodu. MOŻE ona zawierać
+   zmiany na poziomie patch. Numer wersji patch MUSI być ustawiony na 0, gdy wersja
+   minor jest zwiększana.
 
 8. Wersja major X (X.y.z | X > 0) MUSI zostać zwiększona, jeżeli do publicznego
-API są wprowadzane jakiekolwiek wstecznie niekompatybilne zmiany. MOŻE zawierać
-zmiany na poziomie minor oraz patch. Numery wersji minor oraz patch MUSZĄ być
-ustawione na 0, gdy wersja major jest zwiększana.
+   API są wprowadzane jakiekolwiek wstecznie niekompatybilne zmiany. MOŻE zawierać
+   zmiany na poziomie minor oraz patch. Numery wersji minor oraz patch MUSZĄ być
+   ustawione na 0, gdy wersja major jest zwiększana.
 
 9. Wydanie przedpremierowe MOŻE być oznaczone przez dołączenie dywizu oraz
-zbioru identyfikatorów rozdzielonych kropkami, zaraz za numerem wersji
-patch. Identyfikatory MUSZĄ składać się wyłącznie ze znaków alfanumerycznych
-ASCII oraz myślników [0-9A-Za-z-]. Identyfikatory NIE MOGĄ być puste. Numeryczne
-identyfikatory NIE MOGĄ zawierać wiodących zer. Wydania przedpremierowe
-poprzedzają powiązane z nimi wersje standardowe. Wydanie przedpremierowe
-wskazuje na niestabilność wersji i możliwość niespełniania wymogów
-kompatybilności, które cechują powiązaną z nią standardową wersję. Przykłady:
-1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92.
+   zbioru identyfikatorów rozdzielonych kropkami, zaraz za numerem wersji
+   patch. Identyfikatory MUSZĄ składać się wyłącznie ze znaków alfanumerycznych
+   ASCII oraz myślników [0-9A-Za-z-]. Identyfikatory NIE MOGĄ być puste. Numeryczne
+   identyfikatory NIE MOGĄ zawierać wiodących zer. Wydania przedpremierowe
+   poprzedzają powiązane z nimi wersje standardowe. Wydanie przedpremierowe
+   wskazuje na niestabilność wersji i możliwość niespełniania wymogów
+   kompatybilności, które cechują powiązaną z nią standardową wersję. Przykłady:
+   1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92.
 
 10. Meta-dane buildu MOGĄ być oznaczone przez dołączenie znaku plus oraz zbioru
-identyfikatorów rozdzielonych kropkami, zaraz za numerem wersji patch lub
-wydania przedpremierowego. Identyfikatory MUSZĄ składać się wyłącznie ze znaków
-alfanumerycznych ASCII oraz myślników [0-9A-Za-z-]. Identyfikatory NIE MOGĄ być
-puste. Meta-dane buildu POWINNY być ignorowane przy ustalaniu kolejności wersji.
-Zatem, dwie wersje różniące się tylko meta-danymi buildu mają ten sam stopień
-pierwszeństwa. Przykłady: 1.0.0-alpha+001, 1.0.0+20130313144700,
-1.0.0-beta+exp.sha.5114f85.
+    identyfikatorów rozdzielonych kropkami, zaraz za numerem wersji patch lub
+    wydania przedpremierowego. Identyfikatory MUSZĄ składać się wyłącznie ze znaków
+    alfanumerycznych ASCII oraz myślników [0-9A-Za-z-]. Identyfikatory NIE MOGĄ być
+    puste. Meta-dane buildu POWINNY być ignorowane przy ustalaniu kolejności wersji.
+    Zatem dwie wersje różniące się tylko meta-danymi buildu mają ten sam stopień
+    pierwszeństwa. Przykłady: 1.0.0-alpha+001, 1.0.0+20130313144700,
+    1.0.0-beta+exp.sha.5114f85.
 
 11. Pierwszeństwo odnosi się do sposobu porównywania wersji między sobą podczas
-ich porządkowania. Pierwszeństwo MUSI być ustalane w rozdzieleniu wersji na
-identyfikatory major, minor, patch oraz identyfikator przedpremierowy w podanej
-kolejności (meta-dane buildu nie decydują o pierwszeństwie). Pierwszeństwo jest
-ustalane przez pierwszą różnicę wykrytą podczas porównania każdego
-z identyfikatorów od lewej do prawej: wersje major, minor, patch są zawsze
-porównywane numerycznie. Przykład: 1.0.0 < 2.0.0 < 2.1.0 < 2.1.1. Gdy numery
-wersji major, minor i patch są równe, wydanie przedpremierowe poprzedza wersję
-standardową. Przykładowo: 1.0.0-alpha < 1.0.0. Pierwszeństwo dwóch wydań
-przedpremierowych z takimi samymi numerami wersji major, minor i patch MUSI być
-ustalane przez porównywanie każdego z identyfikatorów rozdzielonych kropkami
-w kierunku od lewej do prawej, póki nie zostanie wykryta różnica w taki sposób:
-identyfikatory złożone z samych cyfr porównywane są numerycznie,
-a identyfikatory z literami lub dywizami porównywane są leksykalnie w kolejności
-ASCII. Identyfikatory numeryczne zawsze poprzedzają identyfikatory
-nienumeryczne. Większy zbiór przedpremierowych pól poprzedza mniejszy zbiór,
-o ile wszystkie poprzedzające identyfikatory są sobie równe. Przykład:
-1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 <
-1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
+    ich porządkowania. Pierwszeństwo MUSI być ustalane w rozdzieleniu wersji na
+    identyfikatory major, minor, patch oraz identyfikator przedpremierowy w podanej
+    kolejności (meta-dane buildu nie decydują o pierwszeństwie). Pierwszeństwo jest
+    ustalane przez pierwszą różnicę wykrytą podczas porównania każdego
+    z identyfikatorów od lewej do prawej: wersje major, minor, patch są zawsze
+    porównywane numerycznie. Przykład: 1.0.0 < 2.0.0 < 2.1.0 < 2.1.1. Gdy numery
+    wersji major, minor i patch są równe, wydanie przedpremierowe poprzedza wersję
+    standardową. Przykładowo: 1.0.0-alpha < 1.0.0. Pierwszeństwo dwóch wydań
+    przedpremierowych z takimi samymi numerami wersji major, minor i patch MUSI być
+    ustalane przez porównywanie każdego z identyfikatorów rozdzielonych kropkami
+    w kierunku od lewej do prawej, póki nie zostanie wykryta różnica w taki sposób:
+    identyfikatory złożone z samych cyfr porównywane są numerycznie,
+    a identyfikatory z literami lub dywizami porównywane są leksykalnie w kolejności
+    ASCII. Identyfikatory numeryczne zawsze poprzedzają identyfikatory
+    nienumeryczne. Większy zbiór przedpremierowych pól poprzedza mniejszy zbiór,
+    o ile wszystkie poprzedzające identyfikatory są sobie równe. Przykład:
+    1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 <
+    1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
+
+Gramatyka poprawnej wersji SemVer w zapisie BNF
+--------------------------------------------------
+```
+<valid semver> ::= <version core>
+                 | <version core> "-" <pre-release>
+                 | <version core> "+" <build>
+                 | <version core> "-" <pre-release> "+" <build>
+
+<version core> ::= <major> "." <minor> "." <patch>
+
+<major> ::= <numeric identifier>
+
+<minor> ::= <numeric identifier>
+
+<patch> ::= <numeric identifier>
+
+<pre-release> ::= <dot-separated pre-release identifiers>
+
+<dot-separated pre-release identifiers> ::= <pre-release identifier>
+                                          | <pre-release identifier> "." <dot-separated pre-release identifiers>
+
+<build> ::= <dot-separated build identifiers>
+
+<dot-separated build identifiers> ::= <build identifier>
+                                    | <build identifier> "." <dot-separated build identifiers>
+
+<pre-release identifier> ::= <alphanumeric identifier>
+                           | <numeric identifier>
+
+<build identifier> ::= <alphanumeric identifier>
+                     | <digits>
+
+<alphanumeric identifier> ::= <non-digit>
+                            | <non-digit> <identifier characters>
+                            | <identifier characters> <non-digit>
+                            | <identifier characters> <non-digit> <identifier characters>
+
+<numeric identifier> ::= "0"
+                       | <positive digit>
+                       | <positive digit> <digits>
+
+<identifier characters> ::= <identifier character>
+                          | <identifier character> <identifier characters>
+
+<identifier character> ::= <digit>
+                         | <non-digit>
+
+<non-digit> ::= <letter>
+              | "-"
+
+<digits> ::= <digit>
+           | <digit> <digits>
+
+<digit> ::= "0"
+          | <positive digit>
+
+<positive digit> ::= "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+
+<letter> ::= "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J"
+           | "K" | "L" | "M" | "N" | "O" | "P" | "Q" | "R" | "S" | "T"
+           | "U" | "V" | "W" | "X" | "Y" | "Z" | "a" | "b" | "c" | "d"
+           | "e" | "f" | "g" | "h" | "i" | "j" | "k" | "l" | "m" | "n"
+           | "o" | "p" | "q" | "r" | "s" | "t" | "u" | "v" | "w" | "x"
+           | "y" | "z"
+```
 
 Dlaczego warto stosować wersjonowanie semantyczne?
 --------------------------------------------------
@@ -158,12 +224,12 @@ zamienić piekło zależności w relikt przeszłości. Rozważmy bibliotekę naz
 3.1.0. Jako że Wóz strażacki korzysta z funkcjonalności, które zostały
 wprowadzone po raz pierwszy w wersji 3.1.0, możesz bezpiecznie założyć, że
 wymagana wersja Drabiny jest większa lub równa 3.1.0, ale mniejsza niż 4.0.0.
-Teraz, gdy staną się dostępne wersje Drabiny 3.1.1 lub 3.2.0, możesz puścić je
+Teraz gdy staną się dostępne wersje Drabiny 3.1.1 lub 3.2.0, możesz puścić je
 w swoim systemie zarządzania pakietami ze świadomością, że będą one kompatybilne
 z istniejącym zależnym oprogramowaniem.
 
 Jako odpowiedzialny programista musisz oczywiście zweryfikować, że każde
-aktualizacje pakietów działają jak powinny. Prawdziwy świat potrafi dać w kość;
+aktualizacje pakietów działają, jak powinny. Prawdziwy świat potrafi dać w kość;
 nic nie możemy z tym zrobić poza zachowaniem czujności. To, co ty możesz zrobić,
 to pozwolić by wersjonowanie semantyczne dostarczyło ci rozsądną metodę
 wydawania i aktualizowania pakietów bez konieczności wydawania nowych
@@ -201,7 +267,7 @@ To jest kwestia odpowiedzialnego programowania i dalekowzroczności.
 Niekompatybilne zmiany nie powinny być wprowadzane z lekkością do
 oprogramowania, które jest zależnością w wielu miejscach. Koszt, który trzeba
 ponieść, by zaktualizować pakiet, może być znamienny. Konieczność podbijania
-wersji major przy wprowadzaniu niekompatybilnych zmian powoduje, że będziesz
+wersji major przy wprowadzaniu niekompatybilnych zmian powoduje, że będziesz
 myślał przez pryzmat siły oddziaływania swoich zmian i szacował stosunek
 poniesionych kosztów do zysków.
 
@@ -210,7 +276,7 @@ poniesionych kosztów do zysków.
 Jako profesjonalny programista jesteś odpowiedzialny za prawidłową dokumentację
 oprogramowania, które jest przeznaczone do użytku przez innych. Zarządzanie
 złożonością oprogramowania jest niezwykle ważną częścią utrzymania sprawności
-projektu, a jest to trudne do zrobienia, jeśli nikt nie wie jak używać twojego
+projektu, a jest to trudne do zrobienia, jeśli nikt nie wie, jak używać twojego
 oprogramowania albo z których metod jest bezpiecznie korzystać. Na dłuższą metę
 wersjonowanie semantyczne oraz obstawanie przy dobrze zdefiniowanym publicznym
 API pozwoli wszystkim i wszystkiemu działać płynnie.
@@ -223,18 +289,18 @@ wsteczną kompatybilność. Nawet w takich okolicznościach niedopuszczalne jest
 modyfikowanie wydanej wersji. Jeśli możesz, opisz błędną wersję i poinformuj
 użytkowników o problemie, aby byli świadomi, że ta wersja jest błędna.
 
-### Co powinienem zrobić jeśli aktualizuję własne zależności bez zmiany publicznego API?
+### Co powinienem zrobić, jeśli aktualizuję własne zależności bez zmiany publicznego API?
 
 Taka aktualizacja jest uznawana za kompatybilną, gdyż nie narusza publicznego
 API. Oprogramowanie, które opiera się na tych samych zależnościach co twój
 pakiet, powinno mieć własną specyfikację zależności, a jego autor zauważy
-konflikt. Ustalenie, czy zmiana jest na poziomie patch lub czy jest modyfikacją
-na poziomie minor zależy od tego, czy zaktualizowałeś zależności w celu naprawy
+konflikt. Ustalenie, czy zmiana jest na poziomie patch lub, czy jest modyfikacją
+na poziomie minor, zależy od tego, czy zaktualizowałeś zależności w celu naprawy
 błędu, czy w celu wprowadzenia nowej funkcjonalności. Zazwyczaj spodziewałbym
 się dodatkowego kodu w tym drugim przypadku, co oczywiście oznacza zwiększenie
 wersji minor.
 
-### Co jeśli nieumyślnie zmieniłem publiczne API w taki sposób, że nie jest już zgodne ze zmianą numeru wersji (tj. kod nieprawidłowo wprowadza zmianę major w wydaniu patch)?
+### Co zrobić, gdy nieumyślnie zmieniłem publiczne API w taki sposób, że nie jest już zgodne ze zmianą numeru wersji (tj. kod nieprawidłowo wprowadza zmianę major w wydaniu patch)?
 
 Postępuj zgodnie z rozsądkiem. Jeśli oprogramowanie używane jest przez wielu
 użytkowników, dla których zmiana publicznego API do poprzednio zamierzonego
@@ -244,21 +310,48 @@ w semantycznym wersjonowaniu chodzi przede wszystkim o przekazanie znaczenia
 zmiany poprzez zmianę numeru wersji. Jeśli zmiany są ważne dla użytkowników,
 poinformuj ich o tym poprzez numer wersji.
 
-### Jak powinienem radzić sobie z dezaprobowaniem funkcjonalności?
+### Jak powinienem radzić sobie z wycofywaniem funkcjonalności?
 
-Dezaprobowanie istniejącej funkcjonalności jest normalną częścią programowania
+Wycofywanie istniejącej funkcjonalności jest normalną częścią programowania
 i często jest konieczne, by móc rozwijać oprogramowanie. Gdy wycofujesz część
 swojego publicznego API, powinieneś zrobić dwie rzeczy: (1) zaktualizować
 dokumentację, by użytkownicy wiedzieli o tej zmianie, (2) wypuścić nowe wydanie
-minor z informacją o zdezaprobowaniu. Zanim całkowicie usuniesz funkcjonalność
+minor z informacją o wycofaniu. Zanim całkowicie usuniesz funkcjonalność
 w nowym wydaniu major, powinno być co najmniej jedno wydanie minor zawierające
-zdezaprobowanie, aby użytkownicy mogli płynnie przejść na nowe API.
+informację o wycofaniu, aby użytkownicy mogli płynnie przejść na nowe API.
 
-### Czy semver ma limit długości na oznaczenie wersji?
+### Czy SemVer ma limit długości na oznaczenie wersji?
 
 Nie, ale miej zdrowy rozsądek. Na przykład numer wersji długi na 255 znaków to
 prawdopodobnie przesada. Ponadto konkretne systemy mogą narzucać swoje własne
 ograniczenia na rozmiar tego ciągu znaków.
+
+### Czy ciąg „v1.2.3” spełnia zasady?
+
+Nie, „v1.2.3” nie jest zgodne z wersjonowaniem semantycznym. Jednak przedrostek „v” jest
+zazwyczaj używany w języku angielskim do oznaczenia, że mamy do czynienia z numerem wersji.
+Skrót „v” od angielskiego słowa „version” jest często spotykany w systemach kontroli wersji.
+Przykładowo, w przypadku `git tag v1.2.3 -m "Release version 1.2.3"`, „v1.2.3” jest nazwą taga,
+a semantyczna wersja to „1.2.3”.
+
+### Czy istnieje sugerowane wyrażenie regularne (RegEx) do weryfikacji porawności SemVer?
+
+Istnieją dwa. Pierwsze wykorzystuje grupy nazwane i jest przeznaczone dla systemów, które
+wspierają tę funkcjonalność (PCRE [Perl Compatible Regular Expressions, np. Perl, PHP i R], Python czy Go).
+
+Patrz: https://regex101.com/r/Ly7O1x/3/
+```
+^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+```
+
+Druga wykorzystuje numerowane grupy przechwytujące (wzór gp1 = major, gp2 = minor, gp3 = patch, gp4 = przedpremierowa i gp5 = meta-dane buildu)
+i jest kompatybilna z ECMA Script (JavaScript), PCRE [Perl Compatible Regular Expressions, np. Perl, PHP i R], Python czy Go.
+
+Patrz: https://regex101.com/r/vkijKf/1/
+
+```
+^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+```
 
 O specyfikacji
 --------------

--- a/lang/pl/spec/v2.0.0.md
+++ b/lang/pl/spec/v2.0.0.md
@@ -90,7 +90,7 @@ w [RFC 2119](http://tools.ietf.org/html/rfc2119).
 7. Wersja minor Y (x.Y.z | x > 0) MUSI zostać zwiększona, jeśli nowa,
    kompatybilna wstecz funkcjonalność zostaje wprowadzona do publicznego API. MUSI
    zostać zwiększona, jeśli jakakolwiek funkcjonalność publicznego API zostaje
-   wycofane. MOŻE zostać zwiększona, jeśli wprowadzone zostają nowe znaczące
+   zdezaprobowana. MOŻE zostać zwiększona, jeśli wprowadzone zostają nowe znaczące
    funkcjonalności lub ulepszenia w obrębie prywatnego kodu. MOŻE ona zawierać
    zmiany na poziomie patch. Numer wersji patch MUSI być ustawiony na 0, gdy wersja
    minor jest zwiększana.
@@ -310,15 +310,15 @@ w semantycznym wersjonowaniu chodzi przede wszystkim o przekazanie znaczenia
 zmiany poprzez zmianę numeru wersji. Jeśli zmiany są ważne dla użytkowników,
 poinformuj ich o tym poprzez numer wersji.
 
-### Jak powinienem radzić sobie z wycofywaniem funkcjonalności?
+### Jak powinienem radzić sobie z dezaprobowaniem funkcjonalności?
 
-Wycofywanie istniejącej funkcjonalności jest normalną częścią programowania
+Dezaprobowanie istniejącej funkcjonalności jest normalną częścią programowania
 i często jest konieczne, by móc rozwijać oprogramowanie. Gdy wycofujesz część
 swojego publicznego API, powinieneś zrobić dwie rzeczy: (1) zaktualizować
 dokumentację, by użytkownicy wiedzieli o tej zmianie, (2) wypuścić nowe wydanie
-minor z informacją o wycofaniu. Zanim całkowicie usuniesz funkcjonalność
+minor z informacją o zdezaprobowaniu. Zanim całkowicie usuniesz funkcjonalność
 w nowym wydaniu major, powinno być co najmniej jedno wydanie minor zawierające
-informację o wycofaniu, aby użytkownicy mogli płynnie przejść na nowe API.
+informację o zdezaprobowanie, aby użytkownicy mogli płynnie przejść na nowe API.
 
 ### Czy SemVer ma limit długości na oznaczenie wersji?
 

--- a/lang/pl/spec/v2.0.0.md
+++ b/lang/pl/spec/v2.0.0.md
@@ -318,7 +318,7 @@ swojego publicznego API, powinieneś zrobić dwie rzeczy: (1) zaktualizować
 dokumentację, by użytkownicy wiedzieli o tej zmianie, (2) wypuścić nowe wydanie
 minor z informacją o zdezaprobowaniu. Zanim całkowicie usuniesz funkcjonalność
 w nowym wydaniu major, powinno być co najmniej jedno wydanie minor zawierające
-informację o zdezaprobowanie, aby użytkownicy mogli płynnie przejść na nowe API.
+informację o zdezaprobowaniu, aby użytkownicy mogli płynnie przejść na nowe API.
 
 ### Czy SemVer ma limit długości na oznaczenie wersji?
 
@@ -336,16 +336,17 @@ a semantyczna wersja to „1.2.3”.
 
 ### Czy istnieje sugerowane wyrażenie regularne (RegEx) do weryfikacji porawności SemVer?
 
-Istnieją dwa. Pierwsze wykorzystuje grupy nazwane i jest przeznaczone dla systemów, które
-wspierają tę funkcjonalność (PCRE [Perl Compatible Regular Expressions, np. Perl, PHP i R], Python czy Go).
+Istnieją dwa. Pierwsze wykorzystuje grupy nazwane i jest przeznaczone dla systemów, które wspierają tę funkcjonalność (
+PCRE [Perl Compatible Regular Expressions, np. Perl, PHP i R], Python czy Go).
 
 Patrz: https://regex101.com/r/Ly7O1x/3/
 ```
 ^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
 ```
 
-Druga wykorzystuje numerowane grupy przechwytujące (wzór gp1 = major, gp2 = minor, gp3 = patch, gp4 = przedpremierowa i gp5 = meta-dane buildu)
-i jest kompatybilna z ECMA Script (JavaScript), PCRE [Perl Compatible Regular Expressions, np. Perl, PHP i R], Python czy Go.
+Druga wykorzystuje numerowane grupy przechwytujące (wzór gp1 = major, gp2 = minor, gp3 = patch, gp4 = przedpremierowa i gp5 =
+meta-dane buildu) i jest kompatybilna z ECMA Script (JavaScript), PCRE [Perl Compatible Regular Expressions, np. Perl, PHP i R],
+Python czy Go.
 
 Patrz: https://regex101.com/r/vkijKf/1/
 


### PR DESCRIPTION
Update Polish translation by:

* add B-N form grammar section
* add v1.2.3 and RegEx questions translation in FAQ
* correct grammar and words
    * Word "deprecating" is false friend in direct translation to Polish.

Small improvements in `.gitignore` by adding files generated by Jekyll, IntelliJ and asdf
    