### PR TITLE
fix(_config.yml): Change `vi`'s value to native name

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ languages:
   hin: हिन्दी
   ca: català
   hu: magyar
-  vi: vietnamese
+  vi: Tiếng Việt
   hy: Հայերեն
   kab: taqbaylit
   bg: Български


### PR DESCRIPTION
For consistency, every language's name are using their native language, so "vietnamese" should also change to Vietnamese from English. You can search this, in viwiki they let "T" and "V" uppercase.

@JohnTitor 

---

BTW, I'm not a Vietnamese speaker, but I think this is obviously, so I make this changes.

And maybe you need a **unicode-cldr**.