### PR TITLE
Fix formatting for _config.yml

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,2 +1,7 @@
 trailingComma: "es5"
 semi: true
+overrides:
+  - files: "_config.yml"
+    options:
+      semi: false
+      singleQuote: true

--- a/_config.yml
+++ b/_config.yml
@@ -49,6 +49,6 @@ plugins:
   - jekyll-redirect-from
 defaults:
   - scope:
-      path: ""
+      path: ''
     values:
       layout: default


### PR DESCRIPTION
`npm run collect` formats semicolons to single quotes, thus this changes prettierrc to prefer single quotes there.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>