### PR TITLE
Type error in Italin translation (it)

### DIFF
--- a/lang/it/index.md
+++ b/lang/it/index.md
@@ -11,9 +11,9 @@ Sommario
 
 Dato un numero di versione MAJOR.MINOR.PATCH, incrementate la:
 
-1. versione MAJOR quando modificate l'API in modo non retrocompatibile,
-1. versione MINOR quando aggiungete funzionalità in modo retrocompatibile, e
-1. versione PATCH quando correggete bug in modo retrocompatibile.
+1. versione MAJOR quando modificate l'API in modo non retrocompatibile
+1. versione MINOR quando aggiungete funzionalità in modo retrocompatibile
+1. versione PATCH quando correggete bug in modo retrocompatibile
 
 Sono disponibili etichette aggiuntive per il pre-release e i metadati di build come
 estensioni al formato MAJOR.MINOR.PATCH.

--- a/lang/it/spec/v2.0.0.md
+++ b/lang/it/spec/v2.0.0.md
@@ -11,9 +11,9 @@ Sommario
 
 Dato un numero di versione MAJOR.MINOR.PATCH, incrementate la:
 
-1. versione MAJOR quando modificate l'API in modo non retrocompatibile,
-1. versione MINOR quando aggiungete funzionalità in modo retrocompatibile, e
-1. versione PATCH quando correggete bug in modo retrocompatibile.
+1. versione MAJOR quando modificate l'API in modo non retrocompatibile
+1. versione MINOR quando aggiungete funzionalità in modo retrocompatibile
+1. versione PATCH quando correggete bug in modo retrocompatibile
 
 Sono disponibili etichette aggiuntive per il pre-release e i metadati di build come
 estensioni al formato MAJOR.MINOR.PATCH.


### PR DESCRIPTION
In italian language a statement can not end with the word `e`, in this case i suppose is typing error.