### PR TITLE
fix: add swedish translation for "overkill"

### DIFF
--- a/lang/sv/index.md
+++ b/lang/sv/index.md
@@ -219,7 +219,7 @@ nya API:t.
 
 ### Har SemVer en storleksbegränsning på versionssträngen?
 
-Nej, men använd sunt förnuft. En versionssträng på t.ex. 255 tecken är förmodligen overkill.
+Nej, men använd sunt förnuft. En versionssträng på t.ex. 255 tecken är förmodligen överdrivet.
 Dessutom kan vissa system ha egna begränsningar på hur lång den får vara.
 
 ### Är "v1.2.3" en semantisk version?


### PR DESCRIPTION
Added missing translation for the word overkill.

## PR Checklist

- [x] This PR doesn't modify the files in the `spec` dir.
- [x] This PR passes `npm run lint`.
- [ ] (Optional) If you're willing to help reviews about your language's translations, add your name to the `TRANSLATORS.md`.
