### PR TITLE
Add favicon to website

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8">
     <link rel="stylesheet" href="/css/main.css">
+    <link href="/assets/500x500(dark).jpg" rel="icon" media="(prefers-color-scheme: light)">
+    <link href="/assets/500x500(light).jpg" rel="icon" media="(prefers-color-scheme: dark)">
     {% if page.custom_css %}
       <link rel="stylesheet" href="/css/{{ page.language }}.css">
     {% endif %}


### PR DESCRIPTION
This PR simply adds dark and light favicons to the website.

It might however be better if the images were available with a transparent background. I'm not an image wizard but can look into making the background transparent for the icon


## PR Checklist

- [x] This PR doesn't modify the files in the `spec` dir.
- [x] This PR passes `npm run lint`.


