### PR TITLE
ITA: add and translate two missing sections

### DIFF
--- a/TRANSLATORS.md
+++ b/TRANSLATORS.md
@@ -17,3 +17,7 @@ This file contains the translation contributors who are willing to help translat
 ## Hebrew
 
 - [@ShlomoCode](https://github.com/ShlomoCode)
+
+## Italian
+
+- [@LorenzoAncora](https://github.com/LorenzoAncora)

--- a/lang/it/index.md
+++ b/lang/it/index.md
@@ -271,6 +271,38 @@ No, ma usate il buon senso. Per esempio, una stringa di versione di 255 caratter
 è eccessiva. Inoltre, sistemi specifici possono imporre i loro limiti sulla 
 dimensione.
 
+
+### "v1.2.3" è una versione semantica?
+
+No, "v1.2.3" non è una versione semantica. Tuttavia, prefissare una versione semantica
+con una "v" è un modo comune (in inglese) di indicare che si tratta di un numero di versione.
+L'abbreviazione "v" per "version" si incontra spesso nel controllo di versione. Esempio:
+`git tag v1.2.3 -m "Release version 1.2.3"`, ove "v1.2.3" è un nome di tag
+e la versione semantica è "1.2.3".
+
+### Esiste una espressione regolare (RegEx) suggerita per controllare la stringa SemVer?
+
+Ne esistono due. Una con i gruppi nominati per quei sistemi che li supportano
+(PCRE [Perl Compatible Regular Expressions, i.e. Perl, PHP ed R], Python
+e Go).
+
+Vedi: <https://regex101.com/r/Ly7O1x/3/>
+
+```
+^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+```
+
+...ed una con invece i gruppi di cattura numerati (quindi cg1 = major, cg2 = minor,
+cg3 = patch, cg4 = prerelease and cg5 = buildmetadata) che è compatibile
+con ECMA Script (JavaScript), PCRE (Perl Compatible Regular Expressions,
+i.e. Perl, PHP ed R), Python e Go.
+
+Vedi: <https://regex101.com/r/vkijKf/1/>
+
+```
+^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+```
+
 A riguardo
 ----------
 
@@ -283,6 +315,8 @@ Traduzione a cura del [Java User Group Padova](http://www.jugpadova.it/):
 - [Enrico Mezzato](https://github.com/mezzato) (revisore)
 - [Emanuele Gesuato](http://nonsolojava.blogspot.it/) (revisore)
 - [Anicet Foba Togue](https://twitter.com/atogue) (revisore)
+
+...e di [Lorenzo L. Ancora](https://www.lorenzoancora.info) (autore)
 
 Per lasciare il vostro feedback per favore [aprite una segnalazione su 
 GitHub](https://github.com/semver/semver/issues).

--- a/lang/it/index.md
+++ b/lang/it/index.md
@@ -271,7 +271,6 @@ No, ma usate il buon senso. Per esempio, una stringa di versione di 255 caratter
 è eccessiva. Inoltre, sistemi specifici possono imporre i loro limiti sulla 
 dimensione.
 
-
 ### "v1.2.3" è una versione semantica?
 
 No, "v1.2.3" non è una versione semantica. Tuttavia, prefissare una versione semantica

--- a/lang/it/spec/v2.0.0.md
+++ b/lang/it/spec/v2.0.0.md
@@ -271,6 +271,37 @@ No, ma usate il buon senso. Per esempio, una stringa di versione di 255 caratter
 è eccessiva. Inoltre, sistemi specifici possono imporre i loro limiti sulla 
 dimensione.
 
+### "v1.2.3" è una versione semantica?
+
+No, "v1.2.3" non è una versione semantica. Tuttavia, prefissare una versione semantica
+con una "v" è un modo comune (in inglese) di indicare che si tratta di un numero di versione.
+L'abbreviazione "v" per "version" si incontra spesso nel controllo di versione. Esempio:
+`git tag v1.2.3 -m "Release version 1.2.3"`, ove "v1.2.3" è un nome di tag
+e la versione semantica è "1.2.3".
+
+### Esiste una espressione regolare (RegEx) suggerita per controllare la stringa SemVer?
+
+Ne esistono due. Una con i gruppi nominati per quei sistemi che li supportano
+(PCRE [Perl Compatible Regular Expressions, i.e. Perl, PHP ed R], Python
+e Go).
+
+Vedi: <https://regex101.com/r/Ly7O1x/3/>
+
+```
+^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+```
+
+...ed una con invece i gruppi di cattura numerati (quindi cg1 = major, cg2 = minor,
+cg3 = patch, cg4 = prerelease and cg5 = buildmetadata) che è compatibile
+con ECMA Script (JavaScript), PCRE (Perl Compatible Regular Expressions,
+i.e. Perl, PHP ed R), Python e Go.
+
+Vedi: <https://regex101.com/r/vkijKf/1/>
+
+```
+^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+```
+
 A riguardo
 ----------
 
@@ -283,6 +314,8 @@ Traduzione a cura del [Java User Group Padova](http://www.jugpadova.it/):
 - [Enrico Mezzato](https://github.com/mezzato) (revisore)
 - [Emanuele Gesuato](http://nonsolojava.blogspot.it/) (revisore)
 - [Anicet Foba Togue](https://twitter.com/atogue) (revisore)
+
+...e di [Lorenzo L. Ancora](https://www.lorenzoancora.info) (autore)
 
 Se vi piacerebbe lasciare un commento, per favore [aprite una segnalazione su 
 GitHub](https://github.com/semver/semver/issues).


### PR DESCRIPTION
This PR adds two sections which were missing from the Italian translation:

- Is “v1.2.3” a semantic version?
- Is there a suggested regular expression (RegEx) to check a SemVer string?

Both are full Italian translations.


## PR Checklist

- [X] This PR doesn't modify the files in the `spec` dir.
- [X] This PR passes `npm run lint`.
- [X] (Optional) If you're willing to help reviews about your language's translations, add your name to the `TRANSLATORS.md`.
