### PR TITLE
Use Serbian Cyrillic as default

### DIFF
--- a/lang/sr-Cyrl/index.md
+++ b/lang/sr-Cyrl/index.md
@@ -1,6 +1,9 @@
 ---
 title: Семантичко Верзионисање 2.0.0
 language: sr-Cyrl
+redirect_from:
+  - /lang/sr/
+  - /lang/sr/index.html
 author: Aleksandar Marinković, Radoš Milićev
 ---
 

--- a/lang/sr-Cyrl/spec/v2.0.0.md
+++ b/lang/sr-Cyrl/spec/v2.0.0.md
@@ -1,6 +1,9 @@
 ---
 title: Семантичко Верзионисање 2.0.0
 language: sr-Cyrl
+redirect_from:
+  - /lang/sr/spec/v2.0.0.html
+  - /lang/sr/spec/v2.0.0/
 author: Aleksandar Marinković, Radoš Milićev
 ---
 

--- a/lang/sr-Latn/index.md
+++ b/lang/sr-Latn/index.md
@@ -1,9 +1,6 @@
 ---
 title: Semantičko Verzionisanje 2.0.0
 language: sr-Latn
-redirect_from:
-  - /lang/sr/
-  - /lang/sr/index.html
 author: Aleksandar Marinković, Radoš Milićev
 ---
 

--- a/lang/sr-Latn/spec/v2.0.0.md
+++ b/lang/sr-Latn/spec/v2.0.0.md
@@ -1,9 +1,6 @@
 ---
 title: Semantičko Verzionisanje 2.0.0
 language: sr-Latn
-redirect_from:
-  - /lang/sr/spec/v2.0.0.html
-  - /lang/sr/spec/v2.0.0/
 author: Aleksandar Marinković, Radoš Milićev
 ---
 


### PR DESCRIPTION
Hello @JohnTitor, in #481 you've added Latin Serbian as default, but we should use Cyrillic because it's the official version in Serbia.
